### PR TITLE
Untangle megacities - China

### DIFF
--- a/data/102/027/337/102027337.geojson
+++ b/data/102/027/337/102027337.geojson
@@ -315,6 +315,8 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl_centroid":"mapshaper",
+    "src:population":"wk",
+    "src:population_date":"2010-01-01",
     "wd:wordcount":2226,
     "wof:belongsto":[
         85669787,
@@ -344,11 +346,13 @@
         }
     ],
     "wof:id":102027337,
-    "wof:lastmodified":1566655631,
+    "wof:lastmodified":1578087878,
     "wof:megacity":1,
     "wof:name":"Luzhou",
     "wof:parent_id":890514155,
     "wof:placetype":"locality",
+    "wof:population":919832,
+    "wof:population_rank":11,
     "wof:repo":"whosonfirst-data-admin-cn",
     "wof:scale":6,
     "wof:superseded_by":[],

--- a/data/102/027/369/102027369.geojson
+++ b/data/102/027/369/102027369.geojson
@@ -347,6 +347,8 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl_centroid":"mapshaper",
+    "src:population":"wk",
+    "src:population_date":"2010-01-01",
     "wd:wordcount":1120,
     "wof:belongsto":[
         85669717,
@@ -360,7 +362,8 @@
         "gn:id":1803300,
         "gp:id":26198175,
         "qs_pg:id":1077118,
-        "wd:id":"Q38968"
+        "wd:id":"Q38968",
+        "wk:page":"Liuzhou"
     },
     "wof:country":"CN",
     "wof:geomhash":"3739846b8022f8f8a815b7b7afa8e367",
@@ -375,11 +378,13 @@
         }
     ],
     "wof:id":102027369,
-    "wof:lastmodified":1566655679,
+    "wof:lastmodified":1578087881,
     "wof:megacity":1,
     "wof:name":"Liuzhou",
     "wof:parent_id":890515127,
     "wof:placetype":"locality",
+    "wof:population":1436599,
+    "wof:population_rank":12,
     "wof:repo":"whosonfirst-data-admin-cn",
     "wof:scale":6,
     "wof:superseded_by":[],


### PR DESCRIPTION
Fixes a portion of whosonfirst-data/whosonfirst-data#701

This PR fixes an issue with properties for "megacity" records in China. Two records flagged as megacities do not currently have population, population rank, or population source properties; this PR corrects that.

No PIP work required, can be merged as-is.