### PR TITLE
cn concordances, placetype local, and more

### DIFF
--- a/data/110/873/233/1/1108732331.geojson
+++ b/data/110/873/233/1/1108732331.geojson
@@ -59,7 +59,10 @@
         85669759
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"73843685"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824089,
     "wof:geomhash":"40d64882a83bd4c8a6a72b758951126a",
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":1108732331,
-    "wof:lastmodified":1694639689,
+    "wof:lastmodified":1695886609,
     "wof:name":"Wanning",
     "wof:parent_id":85669759,
     "wof:placetype":"county",

--- a/data/110/873/233/3/1108732333.geojson
+++ b/data/110/873/233/3/1108732333.geojson
@@ -183,8 +183,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.HA.SY"
+        "hasc:id":"CN.HA.SY",
+        "meso:local_id":"73843686"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824093,
     "wof:geomhash":"6f148becbe96273c1d7db93185250c9f",
@@ -197,7 +199,7 @@
         }
     ],
     "wof:id":1108732333,
-    "wof:lastmodified":1694493394,
+    "wof:lastmodified":1695886120,
     "wof:name":"Sanya",
     "wof:parent_id":85669759,
     "wof:placetype":"county",

--- a/data/110/873/233/5/1108732335.geojson
+++ b/data/110/873/233/5/1108732335.geojson
@@ -59,7 +59,10 @@
         85669759
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"73843691"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824096,
     "wof:geomhash":"c914c2270006e7464a389288c4794c70",
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":1108732335,
-    "wof:lastmodified":1694639689,
+    "wof:lastmodified":1695886609,
     "wof:name":"Dongfang",
     "wof:parent_id":85669759,
     "wof:placetype":"county",

--- a/data/110/873/233/7/1108732337.geojson
+++ b/data/110/873/233/7/1108732337.geojson
@@ -175,8 +175,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.SX.LF"
+        "hasc:id":"CN.SX.LF",
+        "meso:local_id":"73843697"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824099,
     "wof:geomhash":"7c72f3e2c7e3d8583f913f8774cdbb36",
@@ -190,7 +195,7 @@
         }
     ],
     "wof:id":1108732337,
-    "wof:lastmodified":1694493394,
+    "wof:lastmodified":1695886120,
     "wof:name":"Linfen",
     "wof:parent_id":85669773,
     "wof:placetype":"county",

--- a/data/110/873/233/9/1108732339.geojson
+++ b/data/110/873/233/9/1108732339.geojson
@@ -178,8 +178,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.SD.LY"
+        "hasc:id":"CN.SD.LY",
+        "meso:local_id":"73843698"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824101,
     "wof:geomhash":"bd34118d1a112609215f9c01fe2ed636",
@@ -193,7 +198,7 @@
         }
     ],
     "wof:id":1108732339,
-    "wof:lastmodified":1694493394,
+    "wof:lastmodified":1695886120,
     "wof:name":"Linyi",
     "wof:parent_id":85669813,
     "wof:placetype":"county",

--- a/data/110/873/234/1/1108732341.geojson
+++ b/data/110/873/234/1/1108732341.geojson
@@ -59,7 +59,10 @@
         85669759
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"73843700"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824105,
     "wof:geomhash":"8b148ba65e21bb6a0add513c52241469",
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":1108732341,
-    "wof:lastmodified":1694639689,
+    "wof:lastmodified":1695886609,
     "wof:name":"Lingao",
     "wof:parent_id":85669759,
     "wof:placetype":"county",

--- a/data/110/873/234/3/1108732343.geojson
+++ b/data/110/873/234/3/1108732343.geojson
@@ -76,8 +76,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.NM.WL"
+        "hasc:id":"CN.NM.WL",
+        "meso:local_id":"73843704"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824108,
     "wof:geomhash":"3633bae53843487c831f192b51a88d88",
@@ -91,7 +96,7 @@
         }
     ],
     "wof:id":1108732343,
-    "wof:lastmodified":1694493393,
+    "wof:lastmodified":1695886505,
     "wof:name":"Wulanchabu",
     "wof:parent_id":85669847,
     "wof:placetype":"county",

--- a/data/110/873/234/5/1108732345.geojson
+++ b/data/110/873/234/5/1108732345.geojson
@@ -59,7 +59,10 @@
         85669759
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"73843707"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824110,
     "wof:geomhash":"54c29fb8f83c97269a1a343aca04caf7",
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":1108732345,
-    "wof:lastmodified":1694639689,
+    "wof:lastmodified":1695886609,
     "wof:name":"Ledong Li",
     "wof:parent_id":85669759,
     "wof:placetype":"county",

--- a/data/110/873/234/9/1108732349.geojson
+++ b/data/110/873/234/9/1108732349.geojson
@@ -63,7 +63,10 @@
         136253041
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"73843711"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824113,
     "wof:geomhash":"f9a65e7d519931de726f2863605dbd81",
@@ -77,7 +80,7 @@
         }
     ],
     "wof:id":1108732349,
-    "wof:lastmodified":1694493394,
+    "wof:lastmodified":1695886508,
     "wof:name":"Zizhiqu Zhixiaxian Jixingzheng Quhua",
     "wof:parent_id":85669753,
     "wof:placetype":"county",

--- a/data/110/873/235/1/1108732351.geojson
+++ b/data/110/873/235/1/1108732351.geojson
@@ -59,7 +59,10 @@
         85669759
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"73843712"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824116,
     "wof:geomhash":"fd140ef7e0ff893395c158076dc585cc",
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":1108732351,
-    "wof:lastmodified":1694639688,
+    "wof:lastmodified":1695886607,
     "wof:name":"Wuzhishan",
     "wof:parent_id":85669759,
     "wof:placetype":"county",

--- a/data/110/873/235/3/1108732353.geojson
+++ b/data/110/873/235/3/1108732353.geojson
@@ -60,7 +60,10 @@
         136253041
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"73843714"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824119,
     "wof:geomhash":"3816ff1c8b30d42b8909e4dcb0b43591",
@@ -74,7 +77,7 @@
         }
     ],
     "wof:id":1108732353,
-    "wof:lastmodified":1694639688,
+    "wof:lastmodified":1695886607,
     "wof:name":"Xiantao",
     "wof:parent_id":85669777,
     "wof:placetype":"county",

--- a/data/110/873/235/5/1108732355.geojson
+++ b/data/110/873/235/5/1108732355.geojson
@@ -85,8 +85,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.XJ.YL"
+        "hasc:id":"CN.XJ.YL",
+        "meso:local_id":"73843716"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824122,
     "wof:geomhash":"3e7082f7e5cd2df028954d9b9502b741",
@@ -100,7 +105,7 @@
         }
     ],
     "wof:id":1108732355,
-    "wof:lastmodified":1694493370,
+    "wof:lastmodified":1695886608,
     "wof:name":"Yili",
     "wof:parent_id":85669753,
     "wof:placetype":"county",

--- a/data/110/873/235/7/1108732357.geojson
+++ b/data/110/873/235/7/1108732357.geojson
@@ -59,7 +59,10 @@
         85669759
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"73843719"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824125,
     "wof:geomhash":"e6fba955d65efedc1ae4dd124b9649b3",
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":1108732357,
-    "wof:lastmodified":1694639689,
+    "wof:lastmodified":1695886288,
     "wof:name":"Baoting Li and Miao",
     "wof:parent_id":85669759,
     "wof:placetype":"county",

--- a/data/110/873/235/9/1108732359.geojson
+++ b/data/110/873/235/9/1108732359.geojson
@@ -59,7 +59,10 @@
         85669759
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"73843723"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824128,
     "wof:geomhash":"9502c151f84cc587b2bdc501c96715df",
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":1108732359,
-    "wof:lastmodified":1694639688,
+    "wof:lastmodified":1695886607,
     "wof:name":"Danzhou",
     "wof:parent_id":85669759,
     "wof:placetype":"county",

--- a/data/110/873/236/1/1108732361.geojson
+++ b/data/110/873/236/1/1108732361.geojson
@@ -76,8 +76,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.XJ.KZ"
+        "hasc:id":"CN.XJ.KZ",
+        "meso:local_id":"73843724"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824131,
     "wof:geomhash":"9b931bc471a8d7349e9ebafb0a84b03d",
@@ -91,7 +96,7 @@
         }
     ],
     "wof:id":1108732361,
-    "wof:lastmodified":1694493390,
+    "wof:lastmodified":1695886498,
     "wof:name":"Kezilesu",
     "wof:parent_id":85669753,
     "wof:placetype":"county",

--- a/data/110/873/236/3/1108732363.geojson
+++ b/data/110/873/236/3/1108732363.geojson
@@ -169,8 +169,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.GZ.LP"
+        "hasc:id":"CN.GZ.LP",
+        "meso:local_id":"73843727"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824135,
     "wof:geomhash":"5007b6fa9e43e133c1a463b5bf295664",
@@ -184,7 +189,7 @@
         }
     ],
     "wof:id":1108732363,
-    "wof:lastmodified":1694493395,
+    "wof:lastmodified":1695886122,
     "wof:name":"Liupanshui",
     "wof:parent_id":85669721,
     "wof:placetype":"county",

--- a/data/110/873/236/7/1108732367.geojson
+++ b/data/110/873/236/7/1108732367.geojson
@@ -88,8 +88,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.NM.XG"
+        "hasc:id":"CN.NM.XG",
+        "meso:local_id":"73843729"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824138,
     "wof:geomhash":"614cbe735fefc31efa77cd646d599d24",
@@ -103,7 +108,7 @@
         }
     ],
     "wof:id":1108732367,
-    "wof:lastmodified":1694493372,
+    "wof:lastmodified":1695886611,
     "wof:name":"Xing'an",
     "wof:parent_id":85669847,
     "wof:placetype":"county",

--- a/data/110/873/236/9/1108732369.geojson
+++ b/data/110/873/236/9/1108732369.geojson
@@ -175,8 +175,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.SC.NJ"
+        "hasc:id":"CN.SC.NJ",
+        "meso:local_id":"73843730"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824140,
     "wof:geomhash":"c249623cd9b1e7e6b9596ca7b3a45fe8",
@@ -190,7 +195,7 @@
         }
     ],
     "wof:id":1108732369,
-    "wof:lastmodified":1694493395,
+    "wof:lastmodified":1695886123,
     "wof:name":"Neijiang",
     "wof:parent_id":85669787,
     "wof:placetype":"county",

--- a/data/110/873/237/3/1108732373.geojson
+++ b/data/110/873/237/3/1108732373.geojson
@@ -76,8 +76,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.XJ.BT"
+        "hasc:id":"CN.XJ.BT",
+        "meso:local_id":"73843743"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824148,
     "wof:geomhash":"e257494cc168006fa3d265bf457d0bd3",
@@ -91,7 +96,7 @@
         }
     ],
     "wof:id":1108732373,
-    "wof:lastmodified":1694493388,
+    "wof:lastmodified":1695886493,
     "wof:name":"Bo'ertala",
     "wof:parent_id":85669753,
     "wof:placetype":"county",

--- a/data/110/873/237/5/1108732375.geojson
+++ b/data/110/873/237/5/1108732375.geojson
@@ -244,8 +244,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.FJ.XM"
+        "hasc:id":"CN.FJ.XM",
+        "meso:local_id":"73843744"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824152,
     "wof:geomhash":"7d097340b5fa43e251fc269bdbec6bfd",
@@ -259,7 +264,7 @@
         }
     ],
     "wof:id":1108732375,
-    "wof:lastmodified":1694493374,
+    "wof:lastmodified":1695886615,
     "wof:name":"Xiamen",
     "wof:parent_id":85669735,
     "wof:placetype":"county",

--- a/data/110/873/237/7/1108732377.geojson
+++ b/data/110/873/237/7/1108732377.geojson
@@ -166,8 +166,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.HL.SY"
+        "hasc:id":"CN.HL.SY",
+        "meso:local_id":"73843745"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824155,
     "wof:geomhash":"12578423684614733d0650aca69c72e6",
@@ -181,7 +186,7 @@
         }
     ],
     "wof:id":1108732377,
-    "wof:lastmodified":1694493396,
+    "wof:lastmodified":1695886125,
     "wof:name":"Shuangyashan",
     "wof:parent_id":85669849,
     "wof:placetype":"county",

--- a/data/110/873/237/9/1108732379.geojson
+++ b/data/110/873/237/9/1108732379.geojson
@@ -63,7 +63,10 @@
         136253041
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"73843751"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824159,
     "wof:geomhash":"02e1fc38046293b4bcb1d31fe777c7fd",
@@ -77,7 +80,7 @@
         }
     ],
     "wof:id":1108732379,
-    "wof:lastmodified":1694493392,
+    "wof:lastmodified":1695886502,
     "wof:name":"Luliang",
     "wof:parent_id":85669773,
     "wof:placetype":"county",

--- a/data/110/873/238/1/1108732381.geojson
+++ b/data/110/873/238/1/1108732381.geojson
@@ -88,8 +88,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.NX.WZ"
+        "hasc:id":"CN.NX.WZ",
+        "meso:local_id":"73843752"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824162,
     "wof:geomhash":"2195f18de3eb145926c5943c1c253a9a",
@@ -103,7 +108,7 @@
         }
     ],
     "wof:id":1108732381,
-    "wof:lastmodified":1694493372,
+    "wof:lastmodified":1695886611,
     "wof:name":"Wuzhong",
     "wof:parent_id":85669763,
     "wof:placetype":"county",

--- a/data/110/873/238/5/1108732385.geojson
+++ b/data/110/873/238/5/1108732385.geojson
@@ -76,8 +76,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.NM.HL"
+        "hasc:id":"CN.NM.HL",
+        "meso:local_id":"73843754"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824165,
     "wof:geomhash":"4b8f58e7fcb1b6282584411fdda8ddbc",
@@ -91,7 +96,7 @@
         }
     ],
     "wof:id":1108732385,
-    "wof:lastmodified":1694493391,
+    "wof:lastmodified":1695886500,
     "wof:name":"Hulunbei'er",
     "wof:parent_id":85669847,
     "wof:placetype":"county",

--- a/data/110/873/238/7/1108732387.geojson
+++ b/data/110/873/238/7/1108732387.geojson
@@ -170,8 +170,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"CN.XJ.HT",
+        "meso:local_id":"73843756",
         "wd:id":"Q989885"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824168,
     "wof:geomhash":"b18b7f08e692211a84c71866a4b6bd16",
@@ -185,7 +190,7 @@
         }
     ],
     "wof:id":1108732387,
-    "wof:lastmodified":1694493372,
+    "wof:lastmodified":1695886611,
     "wof:name":"Hetian",
     "wof:parent_id":85669753,
     "wof:placetype":"county",

--- a/data/110/873/238/9/1108732389.geojson
+++ b/data/110/873/238/9/1108732389.geojson
@@ -163,8 +163,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.XJ.HM"
+        "hasc:id":"CN.XJ.HM",
+        "meso:local_id":"73843759"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824171,
     "wof:geomhash":"5b9c5d569d03c8b5e1096c861de55226",
@@ -178,7 +183,7 @@
         }
     ],
     "wof:id":1108732389,
-    "wof:lastmodified":1694493395,
+    "wof:lastmodified":1695886123,
     "wof:name":"Hami",
     "wof:parent_id":85669753,
     "wof:placetype":"county",

--- a/data/110/873/239/1/1108732391.geojson
+++ b/data/110/873/239/1/1108732391.geojson
@@ -185,8 +185,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"CN.XJ.KS",
+        "meso:local_id":"73843764",
         "wd:id":"Q739890"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824174,
     "wof:geomhash":"9bbf9239135246ba3656f7aa654e77b2",
@@ -200,7 +205,7 @@
         }
     ],
     "wof:id":1108732391,
-    "wof:lastmodified":1694493373,
+    "wof:lastmodified":1695886614,
     "wof:name":"Kashi",
     "wof:parent_id":85669753,
     "wof:placetype":"county",

--- a/data/110/873/239/3/1108732393.geojson
+++ b/data/110/873/239/3/1108732393.geojson
@@ -85,8 +85,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.GS.JY"
+        "hasc:id":"CN.GS.JY",
+        "meso:local_id":"73843766"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824178,
     "wof:geomhash":"06dbf7a95d55efa2b04a651876172a36",
@@ -100,7 +105,7 @@
         }
     ],
     "wof:id":1108732393,
-    "wof:lastmodified":1694493395,
+    "wof:lastmodified":1695886123,
     "wof:name":"Jiayuguan",
     "wof:parent_id":85669711,
     "wof:placetype":"county",

--- a/data/110/873/239/5/1108732395.geojson
+++ b/data/110/873/239/5/1108732395.geojson
@@ -63,7 +63,10 @@
         136253041
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"73843769"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824180,
     "wof:geomhash":"26baf24147142eb5f5d23e42ecfb13cc",
@@ -77,7 +80,7 @@
         }
     ],
     "wof:id":1108732395,
-    "wof:lastmodified":1694493394,
+    "wof:lastmodified":1695886508,
     "wof:name":"Zizhiqu Zhixiaxian Jixingzheng Quhua",
     "wof:parent_id":85669753,
     "wof:placetype":"county",

--- a/data/110/873/239/7/1108732397.geojson
+++ b/data/110/873/239/7/1108732397.geojson
@@ -157,8 +157,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.XJ.TC"
+        "hasc:id":"CN.XJ.TC",
+        "meso:local_id":"73843770"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824184,
     "wof:geomhash":"c7f51a5864349e0c8322cc99337abbca",
@@ -172,7 +177,7 @@
         }
     ],
     "wof:id":1108732397,
-    "wof:lastmodified":1694493396,
+    "wof:lastmodified":1695886123,
     "wof:name":"Tacheng",
     "wof:parent_id":85669753,
     "wof:placetype":"county",

--- a/data/110/873/239/9/1108732399.geojson
+++ b/data/110/873/239/9/1108732399.geojson
@@ -149,8 +149,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"CN.HL.DX",
+        "meso:local_id":"73843771",
         "wd:id":"Q984457"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824187,
     "wof:geomhash":"574f3b4795915e1332ebf16540f6bbb1",
@@ -164,7 +169,7 @@
         }
     ],
     "wof:id":1108732399,
-    "wof:lastmodified":1694493373,
+    "wof:lastmodified":1695886613,
     "wof:name":"Daxing'anling",
     "wof:parent_id":85669849,
     "wof:placetype":"county",

--- a/data/110/873/240/3/1108732403.geojson
+++ b/data/110/873/240/3/1108732403.geojson
@@ -157,8 +157,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.YN.DL"
+        "hasc:id":"CN.YN.DL",
+        "meso:local_id":"73843774"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824190,
     "wof:geomhash":"e63f3addd5b40d7445b10c763ea9a8a9",
@@ -172,7 +177,7 @@
         }
     ],
     "wof:id":1108732403,
-    "wof:lastmodified":1694493395,
+    "wof:lastmodified":1695886122,
     "wof:name":"Dali",
     "wof:parent_id":85669791,
     "wof:placetype":"county",

--- a/data/110/873/240/5/1108732405.geojson
+++ b/data/110/873/240/5/1108732405.geojson
@@ -57,7 +57,10 @@
         136253041
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"73843778"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824193,
     "wof:geomhash":"908e0379f6a432aaf8f8829d20d2f420",
@@ -71,7 +74,7 @@
         }
     ],
     "wof:id":1108732405,
-    "wof:lastmodified":1694639689,
+    "wof:lastmodified":1695886610,
     "wof:name":"Tianme",
     "wof:parent_id":85669777,
     "wof:placetype":"county",

--- a/data/110/873/240/7/1108732407.geojson
+++ b/data/110/873/240/7/1108732407.geojson
@@ -169,8 +169,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.HU.XG"
+        "hasc:id":"CN.HU.XG",
+        "meso:local_id":"73843782"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824196,
     "wof:geomhash":"928f2624677c8372d6c4a2f99c37addc",
@@ -184,7 +189,7 @@
         }
     ],
     "wof:id":1108732407,
-    "wof:lastmodified":1694493395,
+    "wof:lastmodified":1695886122,
     "wof:name":"Xiaogan",
     "wof:parent_id":85669777,
     "wof:placetype":"county",

--- a/data/110/873/240/9/1108732409.geojson
+++ b/data/110/873/240/9/1108732409.geojson
@@ -59,7 +59,10 @@
         85669759
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"73843789"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824200,
     "wof:geomhash":"e2a0cef7d2cfc5a16b6001e890bbebb4",
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":1108732409,
-    "wof:lastmodified":1694639689,
+    "wof:lastmodified":1695886610,
     "wof:name":"Ding'an",
     "wof:parent_id":85669759,
     "wof:placetype":"county",

--- a/data/110/873/241/1/1108732411.geojson
+++ b/data/110/873/241/1/1108732411.geojson
@@ -62,7 +62,10 @@
         85669759
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"73843798"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824203,
     "wof:geomhash":"420bff70fd564797eb40c86cd18b9826",
@@ -75,7 +78,7 @@
         }
     ],
     "wof:id":1108732411,
-    "wof:lastmodified":1694639689,
+    "wof:lastmodified":1695886609,
     "wof:name":"Tunchan",
     "wof:parent_id":85669759,
     "wof:placetype":"county",

--- a/data/110/873/241/3/1108732413.geojson
+++ b/data/110/873/241/3/1108732413.geojson
@@ -154,8 +154,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.SC.BZ"
+        "hasc:id":"CN.SC.BZ",
+        "meso:local_id":"73843802"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824208,
     "wof:geomhash":"70b6442ccb4e137c6674cfce76bbd036",
@@ -169,7 +174,7 @@
         }
     ],
     "wof:id":1108732413,
-    "wof:lastmodified":1694493371,
+    "wof:lastmodified":1695886609,
     "wof:name":"Bazhong",
     "wof:parent_id":85669787,
     "wof:placetype":"county",

--- a/data/110/873/241/5/1108732415.geojson
+++ b/data/110/873/241/5/1108732415.geojson
@@ -76,8 +76,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.NM.BY"
+        "hasc:id":"CN.NM.BY",
+        "meso:local_id":"73843803"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824211,
     "wof:geomhash":"a7ababb141f95bd09bc36d7aa7e8562c",
@@ -91,7 +96,7 @@
         }
     ],
     "wof:id":1108732415,
-    "wof:lastmodified":1694493387,
+    "wof:lastmodified":1695886491,
     "wof:name":"Bayannao'er",
     "wof:parent_id":85669847,
     "wof:placetype":"county",

--- a/data/110/873/241/7/1108732417.geojson
+++ b/data/110/873/241/7/1108732417.geojson
@@ -76,8 +76,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.XJ.BY"
+        "hasc:id":"CN.XJ.BY",
+        "meso:local_id":"73843804"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824213,
     "wof:geomhash":"f413d353c5a93c37bae91d42227e97c7",
@@ -91,7 +96,7 @@
         }
     ],
     "wof:id":1108732417,
-    "wof:lastmodified":1694493387,
+    "wof:lastmodified":1695886491,
     "wof:name":"Bayinguoleng",
     "wof:parent_id":85669753,
     "wof:placetype":"county",

--- a/data/110/873/242/1/1108732421.geojson
+++ b/data/110/873/242/1/1108732421.geojson
@@ -82,8 +82,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.JL.YB"
+        "hasc:id":"CN.JL.YB",
+        "meso:local_id":"73843815"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824219,
     "wof:geomhash":"18d40556f78d317f77127a7754cad395",
@@ -97,7 +102,7 @@
         }
     ],
     "wof:id":1108732421,
-    "wof:lastmodified":1694493408,
+    "wof:lastmodified":1695886539,
     "wof:name":"Yanbian",
     "wof:parent_id":85669843,
     "wof:placetype":"county",

--- a/data/110/873/242/3/1108732423.geojson
+++ b/data/110/873/242/3/1108732423.geojson
@@ -76,8 +76,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.YN.DH"
+        "hasc:id":"CN.YN.DH",
+        "meso:local_id":"73843821"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824222,
     "wof:geomhash":"269f5bcccea5f0ee016994ba1104a8f9",
@@ -91,7 +96,7 @@
         }
     ],
     "wof:id":1108732423,
-    "wof:lastmodified":1694493388,
+    "wof:lastmodified":1695886494,
     "wof:name":"Dehong",
     "wof:parent_id":85669791,
     "wof:placetype":"county",

--- a/data/110/873/242/5/1108732425.geojson
+++ b/data/110/873/242/5/1108732425.geojson
@@ -82,8 +82,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.YN.NJ"
+        "hasc:id":"CN.YN.NJ",
+        "meso:local_id":"73843826"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824235,
     "wof:geomhash":"8d84ed71597ef263ede8b89fcf228d31",
@@ -97,7 +102,7 @@
         }
     ],
     "wof:id":1108732425,
-    "wof:lastmodified":1694493392,
+    "wof:lastmodified":1695886502,
     "wof:name":"Nujiang",
     "wof:parent_id":85669791,
     "wof:placetype":"county",

--- a/data/110/873/242/7/1108732427.geojson
+++ b/data/110/873/242/7/1108732427.geojson
@@ -75,7 +75,10 @@
         136253041
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"73843827"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824238,
     "wof:geomhash":"4c7cd96921439713995a55362bafcb6c",
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":1108732427,
-    "wof:lastmodified":1694493389,
+    "wof:lastmodified":1695886496,
     "wof:name":"Enshi",
     "wof:parent_id":85669777,
     "wof:placetype":"county",

--- a/data/110/873/242/9/1108732429.geojson
+++ b/data/110/873/242/9/1108732429.geojson
@@ -169,8 +169,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.GD.JY"
+        "hasc:id":"CN.GD.JY",
+        "meso:local_id":"73843835"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824242,
     "wof:geomhash":"5fa18e5615225d56e245c6461f90b144",
@@ -184,7 +189,7 @@
         }
     ],
     "wof:id":1108732429,
-    "wof:lastmodified":1694493369,
+    "wof:lastmodified":1695886605,
     "wof:name":"Jieyang",
     "wof:parent_id":85669743,
     "wof:placetype":"county",

--- a/data/110/873/243/1/1108732431.geojson
+++ b/data/110/873/243/1/1108732431.geojson
@@ -103,8 +103,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.YN.WS"
+        "hasc:id":"CN.YN.WS",
+        "meso:local_id":"73843837"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824244,
     "wof:geomhash":"e7295715fc1f046a5a26e4b4c9d6e8ae",
@@ -118,7 +123,7 @@
         }
     ],
     "wof:id":1108732431,
-    "wof:lastmodified":1694493394,
+    "wof:lastmodified":1695886118,
     "wof:name":"Wenshan",
     "wof:parent_id":85669791,
     "wof:placetype":"county",

--- a/data/110/873/243/3/1108732433.geojson
+++ b/data/110/873/243/3/1108732433.geojson
@@ -59,7 +59,10 @@
         85669759
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"73843838"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824248,
     "wof:geomhash":"63442f7accd5df3bada829f992976eec",
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":1108732433,
-    "wof:lastmodified":1694639688,
+    "wof:lastmodified":1695886605,
     "wof:name":"Wenchang",
     "wof:parent_id":85669759,
     "wof:placetype":"county",

--- a/data/110/873/243/5/1108732435.geojson
+++ b/data/110/873/243/5/1108732435.geojson
@@ -59,7 +59,10 @@
         85669759
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"73843846"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824252,
     "wof:geomhash":"9fa0a1107ac75d8c7d48f9948b7e072c",
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":1108732435,
-    "wof:lastmodified":1694639688,
+    "wof:lastmodified":1695886605,
     "wof:name":"Changjiang Li",
     "wof:parent_id":85669759,
     "wof:placetype":"county",

--- a/data/110/873/243/9/1108732439.geojson
+++ b/data/110/873/243/9/1108732439.geojson
@@ -144,7 +144,10 @@
         136253041
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"73843857"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824256,
     "wof:geomhash":"26efb72b515abe985a8635523e0202be",
@@ -158,7 +161,7 @@
         }
     ],
     "wof:id":1108732439,
-    "wof:lastmodified":1694493369,
+    "wof:lastmodified":1695886606,
     "wof:name":"Laibin",
     "wof:parent_id":85669717,
     "wof:placetype":"county",

--- a/data/110/873/244/1/1108732441.geojson
+++ b/data/110/873/244/1/1108732441.geojson
@@ -76,8 +76,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.QH.GL"
+        "hasc:id":"CN.QH.GL",
+        "meso:local_id":"73843861"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824259,
     "wof:geomhash":"9ae322b3bc6a648480e1a9e0a28bfce7",
@@ -91,7 +96,7 @@
         }
     ],
     "wof:id":1108732441,
-    "wof:lastmodified":1694493389,
+    "wof:lastmodified":1695886496,
     "wof:name":"Guoluo",
     "wof:parent_id":85669715,
     "wof:placetype":"county",

--- a/data/110/873/244/3/1108732443.geojson
+++ b/data/110/873/244/3/1108732443.geojson
@@ -229,8 +229,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.GX.GL"
+        "hasc:id":"CN.GX.GL",
+        "meso:local_id":"73843865"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824262,
     "wof:geomhash":"d3ec051172116f8eb52aa151eaf1014a",
@@ -244,7 +249,7 @@
         }
     ],
     "wof:id":1108732443,
-    "wof:lastmodified":1694493370,
+    "wof:lastmodified":1695886606,
     "wof:name":"Guilin",
     "wof:parent_id":85669717,
     "wof:placetype":"county",

--- a/data/110/873/244/5/1108732445.geojson
+++ b/data/110/873/244/5/1108732445.geojson
@@ -94,8 +94,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.YN.CX"
+        "hasc:id":"CN.YN.CX",
+        "meso:local_id":"73843868"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824265,
     "wof:geomhash":"1dfd0679a8397846ceced1833687914e",
@@ -109,7 +114,7 @@
         }
     ],
     "wof:id":1108732445,
-    "wof:lastmodified":1694493394,
+    "wof:lastmodified":1695886119,
     "wof:name":"Chuxiong",
     "wof:parent_id":85669791,
     "wof:placetype":"county",

--- a/data/110/873/244/7/1108732447.geojson
+++ b/data/110/873/244/7/1108732447.geojson
@@ -113,8 +113,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"CN.GZ.BJ",
+        "meso:local_id":"73843872",
         "wd:id":"Q163200"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824268,
     "wof:geomhash":"2007ff15f2dffe7d580e86c5d0f337e9",
@@ -128,7 +133,7 @@
         }
     ],
     "wof:id":1108732447,
-    "wof:lastmodified":1694493369,
+    "wof:lastmodified":1695886606,
     "wof:name":"Bijie",
     "wof:parent_id":85669721,
     "wof:placetype":"county",

--- a/data/110/873/244/9/1108732449.geojson
+++ b/data/110/873/244/9/1108732449.geojson
@@ -223,8 +223,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.GD.ST"
+        "hasc:id":"CN.GD.ST",
+        "meso:local_id":"73843875"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824271,
     "wof:geomhash":"89730df8678ae2b418f5075285eea57b",
@@ -238,7 +243,7 @@
         }
     ],
     "wof:id":1108732449,
-    "wof:lastmodified":1694493370,
+    "wof:lastmodified":1695886606,
     "wof:name":"Shantou",
     "wof:parent_id":85669743,
     "wof:placetype":"county",

--- a/data/110/873/245/1/1108732451.geojson
+++ b/data/110/873/245/1/1108732451.geojson
@@ -325,8 +325,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.LN.SY"
+        "hasc:id":"CN.LN.SY",
+        "meso:local_id":"73843879"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824275,
     "wof:geomhash":"f60bd2a6de1004fc0c7e8fbed9c2a15e",
@@ -340,7 +345,7 @@
         }
     ],
     "wof:id":1108732451,
-    "wof:lastmodified":1694493369,
+    "wof:lastmodified":1695886605,
     "wof:name":"Shenyang",
     "wof:parent_id":85669807,
     "wof:placetype":"county",

--- a/data/110/873/245/3/1108732453.geojson
+++ b/data/110/873/245/3/1108732453.geojson
@@ -172,8 +172,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.GX.HC"
+        "hasc:id":"CN.GX.HC",
+        "meso:local_id":"73843881"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824279,
     "wof:geomhash":"c9b77651993615941ca72f148607a1e2",
@@ -187,7 +192,7 @@
         }
     ],
     "wof:id":1108732453,
-    "wof:lastmodified":1694493394,
+    "wof:lastmodified":1695886118,
     "wof:name":"Hechi",
     "wof:parent_id":85669717,
     "wof:placetype":"county",

--- a/data/110/873/245/7/1108732457.geojson
+++ b/data/110/873/245/7/1108732457.geojson
@@ -151,8 +151,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.QH.HD"
+        "hasc:id":"CN.QH.HD",
+        "meso:local_id":"73843890"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824283,
     "wof:geomhash":"d9ed93397daced508f41dde4e2e42271",
@@ -166,7 +171,7 @@
         }
     ],
     "wof:id":1108732457,
-    "wof:lastmodified":1694493369,
+    "wof:lastmodified":1695886605,
     "wof:name":"Haidong",
     "wof:parent_id":85669715,
     "wof:placetype":"county",

--- a/data/110/873/245/9/1108732459.geojson
+++ b/data/110/873/245/9/1108732459.geojson
@@ -243,8 +243,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.HA.HK"
+        "hasc:id":"CN.HA.HK",
+        "meso:local_id":"73843893"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824286,
     "wof:geomhash":"9a3c822e0aa14adc3f7e4e721b83751d",
@@ -257,7 +259,7 @@
         }
     ],
     "wof:id":1108732459,
-    "wof:lastmodified":1694493369,
+    "wof:lastmodified":1695886605,
     "wof:name":"Haikou",
     "wof:parent_id":85669759,
     "wof:placetype":"county",

--- a/data/110/873/246/1/1108732461.geojson
+++ b/data/110/873/246/1/1108732461.geojson
@@ -76,8 +76,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.QH.HX"
+        "hasc:id":"CN.QH.HX",
+        "meso:local_id":"73843894"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824288,
     "wof:geomhash":"6aedaac981d3b0cd5071b38827a6fbad",
@@ -91,7 +96,7 @@
         }
     ],
     "wof:id":1108732461,
-    "wof:lastmodified":1694493390,
+    "wof:lastmodified":1695886497,
     "wof:name":"Haixi Mengguzu",
     "wof:parent_id":85669715,
     "wof:placetype":"county",

--- a/data/110/873/246/3/1108732463.geojson
+++ b/data/110/873/246/3/1108732463.geojson
@@ -193,8 +193,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.AH.HB"
+        "hasc:id":"CN.AH.HB",
+        "meso:local_id":"73843896"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824291,
     "wof:geomhash":"7ca104406e1cbd57550cbd1ae0b53807",
@@ -208,7 +213,7 @@
         }
     ],
     "wof:id":1108732463,
-    "wof:lastmodified":1694493395,
+    "wof:lastmodified":1695886121,
     "wof:name":"Huaibei",
     "wof:parent_id":85669739,
     "wof:placetype":"county",

--- a/data/110/873/246/5/1108732465.geojson
+++ b/data/110/873/246/5/1108732465.geojson
@@ -169,8 +169,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.JS.HY"
+        "hasc:id":"CN.JS.HY",
+        "meso:local_id":"73843898"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824295,
     "wof:geomhash":"68f033fcd26d2ce82a4bcb4ec7e099b2",
@@ -184,7 +189,7 @@
         }
     ],
     "wof:id":1108732465,
-    "wof:lastmodified":1694493371,
+    "wof:lastmodified":1695886610,
     "wof:name":"Huai'an",
     "wof:parent_id":85669827,
     "wof:placetype":"county",

--- a/data/110/873/246/7/1108732467.geojson
+++ b/data/110/873/246/7/1108732467.geojson
@@ -187,8 +187,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.HN.XT"
+        "hasc:id":"CN.HN.XT",
+        "meso:local_id":"73843904"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824298,
     "wof:geomhash":"2adee2837034ff0ba3527ff0a2b0cff2",
@@ -202,7 +207,7 @@
         }
     ],
     "wof:id":1108732467,
-    "wof:lastmodified":1694493395,
+    "wof:lastmodified":1695886121,
     "wof:name":"Xiangtan",
     "wof:parent_id":85669781,
     "wof:placetype":"county",

--- a/data/110/873/246/9/1108732469.geojson
+++ b/data/110/873/246/9/1108732469.geojson
@@ -166,8 +166,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.SD.BS"
+        "hasc:id":"CN.SD.BS",
+        "meso:local_id":"73843908"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824302,
     "wof:geomhash":"9207512cbf575ead35678c9e5f3123e5",
@@ -181,7 +186,7 @@
         }
     ],
     "wof:id":1108732469,
-    "wof:lastmodified":1694493371,
+    "wof:lastmodified":1695886609,
     "wof:name":"Binzhou",
     "wof:parent_id":85669813,
     "wof:placetype":"county",

--- a/data/110/873/247/1/1108732471.geojson
+++ b/data/110/873/247/1/1108732471.geojson
@@ -60,7 +60,10 @@
         136253041
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"73843912"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824305,
     "wof:geomhash":"8e62d1b4aeaa93085e2af0e6962ff6df",
@@ -74,7 +77,7 @@
         }
     ],
     "wof:id":1108732471,
-    "wof:lastmodified":1694639689,
+    "wof:lastmodified":1695886610,
     "wof:name":"Qianjiang",
     "wof:parent_id":85669777,
     "wof:placetype":"county",

--- a/data/110/873/247/5/1108732475.geojson
+++ b/data/110/873/247/5/1108732475.geojson
@@ -59,7 +59,10 @@
         85669759
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"73843914"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824308,
     "wof:geomhash":"9d41af1abe9942f05dbdce7082fc3a3f",
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":1108732475,
-    "wof:lastmodified":1694639689,
+    "wof:lastmodified":1695886610,
     "wof:name":"Chengmai",
     "wof:parent_id":85669759,
     "wof:placetype":"county",

--- a/data/110/873/247/7/1108732477.geojson
+++ b/data/110/873/247/7/1108732477.geojson
@@ -59,7 +59,10 @@
         85669759
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"73843923"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824313,
     "wof:geomhash":"1507d03e684bde2c55823ded2fe23d22",
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":1108732477,
-    "wof:lastmodified":1694639689,
+    "wof:lastmodified":1695886610,
     "wof:name":"Qiongzhong Li and Miao",
     "wof:parent_id":85669759,
     "wof:placetype":"county",

--- a/data/110/873/247/9/1108732479.geojson
+++ b/data/110/873/247/9/1108732479.geojson
@@ -59,7 +59,10 @@
         85669759
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"73843924"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824315,
     "wof:geomhash":"55422df146a8924670c282d32ffd21b4",
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":1108732479,
-    "wof:lastmodified":1694639689,
+    "wof:lastmodified":1695886610,
     "wof:name":"Qionghai",
     "wof:parent_id":85669759,
     "wof:placetype":"county",

--- a/data/110/873/248/1/1108732481.geojson
+++ b/data/110/873/248/1/1108732481.geojson
@@ -59,7 +59,10 @@
         85669759
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"73843929"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824319,
     "wof:geomhash":"0b854c7400f108b0856253769f34ba3f",
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":1108732481,
-    "wof:lastmodified":1694639689,
+    "wof:lastmodified":1695886609,
     "wof:name":"Baisha Li",
     "wof:parent_id":85669759,
     "wof:placetype":"county",

--- a/data/110/873/248/3/1108732483.geojson
+++ b/data/110/873/248/3/1108732483.geojson
@@ -63,7 +63,10 @@
         136253041
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"73843938"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824323,
     "wof:geomhash":"e70810f341c8acab84f747f50c31e42c",
@@ -77,7 +80,7 @@
         }
     ],
     "wof:id":1108732483,
-    "wof:lastmodified":1694493394,
+    "wof:lastmodified":1695886508,
     "wof:name":"Zizhiqu Zhixiaxian Jixingzheng Quhua",
     "wof:parent_id":85669753,
     "wof:placetype":"county",

--- a/data/110/873/248/5/1108732485.geojson
+++ b/data/110/873/248/5/1108732485.geojson
@@ -136,8 +136,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "meso:local_id":"73843939",
         "wd:id":"Q1359055"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824326,
     "wof:geomhash":"f5f1cbf85013737928a38b5c77794d67",
@@ -151,7 +153,7 @@
         }
     ],
     "wof:id":1108732485,
-    "wof:lastmodified":1694493371,
+    "wof:lastmodified":1695886609,
     "wof:name":"Hubei",
     "wof:parent_id":85669777,
     "wof:placetype":"county",

--- a/data/110/873/248/7/1108732487.geojson
+++ b/data/110/873/248/7/1108732487.geojson
@@ -187,8 +187,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.GD.MM"
+        "hasc:id":"CN.GD.MM",
+        "meso:local_id":"73843952"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824331,
     "wof:geomhash":"62f0ffcd57874a7f21968448630f892e",
@@ -202,7 +207,7 @@
         }
     ],
     "wof:id":1108732487,
-    "wof:lastmodified":1694493395,
+    "wof:lastmodified":1695886121,
     "wof:name":"Maoming",
     "wof:parent_id":85669743,
     "wof:placetype":"county",

--- a/data/110/873/248/9/1108732489.geojson
+++ b/data/110/873/248/9/1108732489.geojson
@@ -131,8 +131,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"CN.HU.JZ",
+        "meso:local_id":"73843953",
         "wd:id":"Q1198838"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824333,
     "wof:geomhash":"9904a92751374d263e8ffaba99620087",
@@ -146,7 +151,7 @@
         }
     ],
     "wof:id":1108732489,
-    "wof:lastmodified":1694493395,
+    "wof:lastmodified":1695886121,
     "wof:name":"Jingzhou",
     "wof:parent_id":85669777,
     "wof:placetype":"county",

--- a/data/110/873/249/3/1108732493.geojson
+++ b/data/110/873/249/3/1108732493.geojson
@@ -169,8 +169,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.SD.LW"
+        "hasc:id":"CN.SD.LW",
+        "meso:local_id":"73843956"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824336,
     "wof:geomhash":"f9efe2a2dd5fbddf3cc7f502e83426db",
@@ -184,7 +189,7 @@
         }
     ],
     "wof:id":1108732493,
-    "wof:lastmodified":1694493395,
+    "wof:lastmodified":1695886122,
     "wof:name":"Laiwu",
     "wof:parent_id":85669813,
     "wof:placetype":"county",

--- a/data/110/873/249/5/1108732495.geojson
+++ b/data/110/873/249/5/1108732495.geojson
@@ -187,8 +187,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.LN.YK"
+        "hasc:id":"CN.LN.YK",
+        "meso:local_id":"73843959"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824340,
     "wof:geomhash":"39bdb592bdada41ae7e0e4bdb6837d27",
@@ -202,7 +207,7 @@
         }
     ],
     "wof:id":1108732495,
-    "wof:lastmodified":1694493372,
+    "wof:lastmodified":1695886611,
     "wof:name":"Yingkou",
     "wof:parent_id":85669807,
     "wof:placetype":"county",

--- a/data/110/873/249/7/1108732497.geojson
+++ b/data/110/873/249/7/1108732497.geojson
@@ -181,8 +181,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.HU.XF"
+        "hasc:id":"CN.HU.XF",
+        "meso:local_id":"73843965"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824344,
     "wof:geomhash":"1354d662ea6649d83e840a4334d778fb",
@@ -196,7 +201,7 @@
         }
     ],
     "wof:id":1108732497,
-    "wof:lastmodified":1694493395,
+    "wof:lastmodified":1695886122,
     "wof:name":"Xiangyang",
     "wof:parent_id":85669777,
     "wof:placetype":"county",

--- a/data/110/873/249/9/1108732499.geojson
+++ b/data/110/873/249/9/1108732499.geojson
@@ -76,8 +76,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.YN.XS"
+        "hasc:id":"CN.YN.XS",
+        "meso:local_id":"73843966"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824347,
     "wof:geomhash":"b02eb46cd47cf4562a8adf5fa20e2ade",
@@ -91,7 +96,7 @@
         }
     ],
     "wof:id":1108732499,
-    "wof:lastmodified":1694493393,
+    "wof:lastmodified":1695886506,
     "wof:name":"Xishuangbanna",
     "wof:parent_id":85669791,
     "wof:placetype":"county",

--- a/data/110/873/250/1/1108732501.geojson
+++ b/data/110/873/250/1/1108732501.geojson
@@ -172,8 +172,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.GX.GG"
+        "hasc:id":"CN.GX.GG",
+        "meso:local_id":"73843970"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824350,
     "wof:geomhash":"45318c7abea249ee0a4baa803bb70f64",
@@ -187,7 +192,7 @@
         }
     ],
     "wof:id":1108732501,
-    "wof:lastmodified":1694493370,
+    "wof:lastmodified":1695886606,
     "wof:name":"Guigang",
     "wof:parent_id":85669717,
     "wof:placetype":"county",

--- a/data/110/873/250/3/1108732503.geojson
+++ b/data/110/873/250/3/1108732503.geojson
@@ -172,8 +172,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.JL.LY"
+        "hasc:id":"CN.JL.LY",
+        "meso:local_id":"73843976"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824353,
     "wof:geomhash":"9f8cf6aac5c846e1bda4cbac8e5dd0e1",
@@ -187,7 +192,7 @@
         }
     ],
     "wof:id":1108732503,
-    "wof:lastmodified":1694493394,
+    "wof:lastmodified":1695886119,
     "wof:name":"Liaoyuan",
     "wof:parent_id":85669843,
     "wof:placetype":"county",

--- a/data/110/873/250/5/1108732505.geojson
+++ b/data/110/873/250/5/1108732505.geojson
@@ -76,8 +76,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.YN.DQ"
+        "hasc:id":"CN.YN.DQ",
+        "meso:local_id":"73843981"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824356,
     "wof:geomhash":"4681c2c8b7f4b3be6da2c78643fceafa",
@@ -91,7 +96,7 @@
         }
     ],
     "wof:id":1108732505,
-    "wof:lastmodified":1694493389,
+    "wof:lastmodified":1695886497,
     "wof:name":"Diqing",
     "wof:parent_id":85669791,
     "wof:placetype":"county",

--- a/data/110/873/250/7/1108732507.geojson
+++ b/data/110/873/250/7/1108732507.geojson
@@ -176,8 +176,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"CN.XZ.NQ",
+        "meso:local_id":"73843987",
         "wd:id":"Q1012460"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824361,
     "wof:geomhash":"50b53a6f4c87b225359dba2539827d34",
@@ -191,7 +196,7 @@
         }
     ],
     "wof:id":1108732507,
-    "wof:lastmodified":1694493370,
+    "wof:lastmodified":1695886607,
     "wof:name":"Naqu",
     "wof:parent_id":85669747,
     "wof:placetype":"county",

--- a/data/110/873/251/1/1108732511.geojson
+++ b/data/110/873/251/1/1108732511.geojson
@@ -172,8 +172,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.GX.QZ"
+        "hasc:id":"CN.GX.QZ",
+        "meso:local_id":"73843998"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824366,
     "wof:geomhash":"b8ee890055bd89f845613473066865f0",
@@ -187,7 +192,7 @@
         }
     ],
     "wof:id":1108732511,
-    "wof:lastmodified":1694493394,
+    "wof:lastmodified":1695886119,
     "wof:name":"Qinzhou",
     "wof:parent_id":85669717,
     "wof:placetype":"county",

--- a/data/110/873/251/3/1108732513.geojson
+++ b/data/110/873/251/3/1108732513.geojson
@@ -137,8 +137,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"CN.GZ.TR",
+        "meso:local_id":"73844000",
         "wd:id":"Q1130793"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824368,
     "wof:geomhash":"25fa6c1ab7509fdccca1db3e8d7e6f3f",
@@ -152,7 +157,7 @@
         }
     ],
     "wof:id":1108732513,
-    "wof:lastmodified":1694493394,
+    "wof:lastmodified":1695886119,
     "wof:name":"Tongren",
     "wof:parent_id":85669721,
     "wof:placetype":"county",

--- a/data/110/873/251/5/1108732515.geojson
+++ b/data/110/873/251/5/1108732515.geojson
@@ -157,8 +157,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.SA.TC"
+        "hasc:id":"CN.SA.TC",
+        "meso:local_id":"73844001"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824371,
     "wof:geomhash":"775b47ad5a6055a8de821bb05da8d37a",
@@ -172,7 +177,7 @@
         }
     ],
     "wof:id":1108732515,
-    "wof:lastmodified":1694493395,
+    "wof:lastmodified":1695886120,
     "wof:name":"Tongchuan",
     "wof:parent_id":85669769,
     "wof:placetype":"county",

--- a/data/110/873/251/7/1108732517.geojson
+++ b/data/110/873/251/7/1108732517.geojson
@@ -226,8 +226,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.NX.YC"
+        "hasc:id":"CN.NX.YC",
+        "meso:local_id":"73844003"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824376,
     "wof:geomhash":"0fde38c06ebd8f5b9d3f3d5d90dd7385",
@@ -241,7 +246,7 @@
         }
     ],
     "wof:id":1108732517,
-    "wof:lastmodified":1694493371,
+    "wof:lastmodified":1695886609,
     "wof:name":"Yinchuan",
     "wof:parent_id":85669763,
     "wof:placetype":"county",

--- a/data/110/873/251/9/1108732519.geojson
+++ b/data/110/873/251/9/1108732519.geojson
@@ -76,8 +76,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.NM.XL"
+        "hasc:id":"CN.NM.XL",
+        "meso:local_id":"73844004"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824379,
     "wof:geomhash":"cd35b54482c8c8d13d6961ec8ee47e9f",
@@ -91,7 +96,7 @@
         }
     ],
     "wof:id":1108732519,
-    "wof:lastmodified":1694493393,
+    "wof:lastmodified":1695886506,
     "wof:name":"Xilinguole",
     "wof:parent_id":85669847,
     "wof:placetype":"county",

--- a/data/110/873/252/1/1108732521.geojson
+++ b/data/110/873/252/1/1108732521.geojson
@@ -193,8 +193,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.JS.ZJ"
+        "hasc:id":"CN.JS.ZJ",
+        "meso:local_id":"73844006"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824382,
     "wof:geomhash":"e049e36a0865148e1ffb03f495c8da2d",
@@ -208,7 +213,7 @@
         }
     ],
     "wof:id":1108732521,
-    "wof:lastmodified":1694493396,
+    "wof:lastmodified":1695886125,
     "wof:name":"Zhenjiang",
     "wof:parent_id":85669827,
     "wof:placetype":"county",

--- a/data/110/873/252/3/1108732523.geojson
+++ b/data/110/873/252/3/1108732523.geojson
@@ -175,8 +175,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.SX.CZ"
+        "hasc:id":"CN.SX.CZ",
+        "meso:local_id":"73844009"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824385,
     "wof:geomhash":"34c288cfd2a7d8a2b6de96a846dd60ba",
@@ -190,7 +195,7 @@
         }
     ],
     "wof:id":1108732523,
-    "wof:lastmodified":1694493396,
+    "wof:lastmodified":1695886126,
     "wof:name":"Changzhi",
     "wof:parent_id":85669773,
     "wof:placetype":"county",

--- a/data/110/873/252/5/1108732525.geojson
+++ b/data/110/873/252/5/1108732525.geojson
@@ -166,8 +166,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.SX.YQ"
+        "hasc:id":"CN.SX.YQ",
+        "meso:local_id":"73844014"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824388,
     "wof:geomhash":"55c445d205ed695cf9bd070fbd3e4e49",
@@ -181,7 +186,7 @@
         }
     ],
     "wof:id":1108732525,
-    "wof:lastmodified":1694493396,
+    "wof:lastmodified":1695886126,
     "wof:name":"Yangquan",
     "wof:parent_id":85669773,
     "wof:placetype":"county",

--- a/data/110/873/252/9/1108732529.geojson
+++ b/data/110/873/252/9/1108732529.geojson
@@ -76,8 +76,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.XJ.AK"
+        "hasc:id":"CN.XJ.AK",
+        "meso:local_id":"73844015"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824391,
     "wof:geomhash":"a824296c01e66662a793b2c4726dac45",
@@ -91,7 +96,7 @@
         }
     ],
     "wof:id":1108732529,
-    "wof:lastmodified":1694493387,
+    "wof:lastmodified":1695886490,
     "wof:name":"Akesu",
     "wof:parent_id":85669753,
     "wof:placetype":"county",

--- a/data/110/873/253/1/1108732531.geojson
+++ b/data/110/873/253/1/1108732531.geojson
@@ -76,8 +76,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.XJ.AL"
+        "hasc:id":"CN.XJ.AL",
+        "meso:local_id":"73844016"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824395,
     "wof:geomhash":"81d2a5ea11f654630e8cff1e472afe52",
@@ -91,7 +96,7 @@
         }
     ],
     "wof:id":1108732531,
-    "wof:lastmodified":1694493388,
+    "wof:lastmodified":1695886492,
     "wof:name":"Aletai",
     "wof:parent_id":85669753,
     "wof:placetype":"county",

--- a/data/110/873/253/3/1108732533.geojson
+++ b/data/110/873/253/3/1108732533.geojson
@@ -82,8 +82,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.NM.AL"
+        "hasc:id":"CN.NM.AL",
+        "meso:local_id":"73844018"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824399,
     "wof:geomhash":"ea9a36255256c79aa0995554a01f7589",
@@ -97,7 +102,7 @@
         }
     ],
     "wof:id":1108732533,
-    "wof:lastmodified":1694493387,
+    "wof:lastmodified":1695886491,
     "wof:name":"Alashan",
     "wof:parent_id":85669847,
     "wof:placetype":"county",

--- a/data/110/873/253/5/1108732535.geojson
+++ b/data/110/873/253/5/1108732535.geojson
@@ -63,7 +63,10 @@
         136253041
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"73844019"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824402,
     "wof:geomhash":"d3b24cbadc7fe93f8b1e033ccf9788e5",
@@ -77,7 +80,7 @@
         }
     ],
     "wof:id":1108732535,
-    "wof:lastmodified":1694493394,
+    "wof:lastmodified":1695886508,
     "wof:name":"Zizhiqu Zhixiaxian Jixingzheng Quhua",
     "wof:parent_id":85669753,
     "wof:placetype":"county",

--- a/data/110/873/253/7/1108732537.geojson
+++ b/data/110/873/253/7/1108732537.geojson
@@ -167,8 +167,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"CN.XZ.AL",
+        "meso:local_id":"73844020",
         "wd:id":"Q577713"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824405,
     "wof:geomhash":"39e2f97dee5310ddd52fa36f3d8de144",
@@ -182,7 +187,7 @@
         }
     ],
     "wof:id":1108732537,
-    "wof:lastmodified":1694493372,
+    "wof:lastmodified":1695886612,
     "wof:name":"Ali",
     "wof:parent_id":85669747,
     "wof:placetype":"county",

--- a/data/110/873/253/9/1108732539.geojson
+++ b/data/110/873/253/9/1108732539.geojson
@@ -59,7 +59,10 @@
         85669759
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"73844022"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1478824409,
     "wof:geomhash":"d3bd7e222ced197f168a0ca977ec98e2",
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":1108732539,
-    "wof:lastmodified":1694639689,
+    "wof:lastmodified":1695886611,
     "wof:name":"Lingshui Li",
     "wof:parent_id":85669759,
     "wof:placetype":"county",

--- a/data/110/873/254/1/1108732541.geojson
+++ b/data/110/873/254/1/1108732541.geojson
@@ -163,8 +163,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.SC.YA"
+        "hasc:id":"CN.SC.YA",
+        "meso:local_id":"73844024"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824412,
     "wof:geomhash":"c7e1019526d0d398c1c3be8c1b3651d3",
@@ -178,7 +183,7 @@
         }
     ],
     "wof:id":1108732541,
-    "wof:lastmodified":1694493373,
+    "wof:lastmodified":1695886613,
     "wof:name":"Ya'an",
     "wof:parent_id":85669787,
     "wof:placetype":"county",

--- a/data/110/873/254/3/1108732543.geojson
+++ b/data/110/873/254/3/1108732543.geojson
@@ -190,8 +190,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.AH.MA"
+        "hasc:id":"CN.AH.MA",
+        "meso:local_id":"73844028"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824415,
     "wof:geomhash":"0315eca2767481f3c6cd0035d014b0a1",
@@ -205,7 +210,7 @@
         }
     ],
     "wof:id":1108732543,
-    "wof:lastmodified":1694493373,
+    "wof:lastmodified":1695886614,
     "wof:name":"Ma'anshan",
     "wof:parent_id":85669739,
     "wof:placetype":"county",

--- a/data/110/873/254/7/1108732547.geojson
+++ b/data/110/873/254/7/1108732547.geojson
@@ -175,8 +175,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.HL.JX"
+        "hasc:id":"CN.HL.JX",
+        "meso:local_id":"73844030"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824418,
     "wof:geomhash":"68ca86fb5ef27bbb4df4b14067773647",
@@ -190,7 +195,7 @@
         }
     ],
     "wof:id":1108732547,
-    "wof:lastmodified":1694493396,
+    "wof:lastmodified":1695886124,
     "wof:name":"Jixi",
     "wof:parent_id":85669849,
     "wof:placetype":"county",

--- a/data/110/873/254/9/1108732549.geojson
+++ b/data/110/873/254/9/1108732549.geojson
@@ -172,8 +172,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.HE.HB"
+        "hasc:id":"CN.HE.HB",
+        "meso:local_id":"73844031"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824421,
     "wof:geomhash":"183578114b4c45892c831aed91a8ac12",
@@ -187,7 +192,7 @@
         }
     ],
     "wof:id":1108732549,
-    "wof:lastmodified":1694493395,
+    "wof:lastmodified":1695886123,
     "wof:name":"Hebi",
     "wof:parent_id":85669801,
     "wof:placetype":"county",

--- a/data/110/873/255/1/1108732551.geojson
+++ b/data/110/873/255/1/1108732551.geojson
@@ -76,8 +76,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.QH.HU"
+        "hasc:id":"CN.QH.HU",
+        "meso:local_id":"73844035"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824424,
     "wof:geomhash":"65bacba38f6d19b948a27910cb11ac72",
@@ -91,7 +96,7 @@
         }
     ],
     "wof:id":1108732551,
-    "wof:lastmodified":1694493390,
+    "wof:lastmodified":1695886498,
     "wof:name":"Huangnan",
     "wof:parent_id":85669715,
     "wof:placetype":"county",

--- a/data/110/873/255/3/1108732553.geojson
+++ b/data/110/873/255/3/1108732553.geojson
@@ -199,8 +199,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.AH.HS"
+        "hasc:id":"CN.AH.HS",
+        "meso:local_id":"73844036"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824427,
     "wof:geomhash":"31d4618d2a5737e220c6e0f862a1ab58",
@@ -214,7 +219,7 @@
         }
     ],
     "wof:id":1108732553,
-    "wof:lastmodified":1694493374,
+    "wof:lastmodified":1695886615,
     "wof:name":"Huangshan",
     "wof:parent_id":85669739,
     "wof:placetype":"county",

--- a/data/110/873/255/5/1108732555.geojson
+++ b/data/110/873/255/5/1108732555.geojson
@@ -187,8 +187,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.HL.HH"
+        "hasc:id":"CN.HL.HH",
+        "meso:local_id":"73844038"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824430,
     "wof:geomhash":"172bfa934e2b2f5a7734e9d2ab05f737",
@@ -202,7 +207,7 @@
         }
     ],
     "wof:id":1108732555,
-    "wof:lastmodified":1694493396,
+    "wof:lastmodified":1695886126,
     "wof:name":"Heihe",
     "wof:parent_id":85669849,
     "wof:placetype":"county",

--- a/data/110/873/255/7/1108732557.geojson
+++ b/data/110/873/255/7/1108732557.geojson
@@ -76,8 +76,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.GZ.QN"
+        "hasc:id":"CN.GZ.QN",
+        "meso:local_id":"73844040"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824434,
     "wof:geomhash":"5b99659a18a469e92fadb17b93eea577",
@@ -91,7 +96,7 @@
         }
     ],
     "wof:id":1108732557,
-    "wof:lastmodified":1694493392,
+    "wof:lastmodified":1695886503,
     "wof:name":"Qiannan",
     "wof:parent_id":85669721,
     "wof:placetype":"county",

--- a/data/110/873/255/9/1108732559.geojson
+++ b/data/110/873/255/9/1108732559.geojson
@@ -76,8 +76,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"CN.GZ.QX"
+        "hasc:id":"CN.GZ.QX",
+        "meso:local_id":"73844041"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1478824437,
     "wof:geomhash":"9f042d551f946deba214e4b510975051",
@@ -91,7 +96,7 @@
         }
     ],
     "wof:id":1108732559,
-    "wof:lastmodified":1694493392,
+    "wof:lastmodified":1695886503,
     "wof:name":"Qianxinan",
     "wof:parent_id":85669721,
     "wof:placetype":"county",

--- a/data/110/879/405/7/1108794057.geojson
+++ b/data/110/879/405/7/1108794057.geojson
@@ -198,10 +198,15 @@
     "wof:concordances":{
         "gn:id":1280019,
         "hasc:id":"CN.XZ.SN",
+        "meso:local_id":"73843799",
         "qs_pg:id":370515,
         "wd:id":"Q777171",
         "wk:page":"Shannan, Tibet"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055779,
     "wof:geomhash":"396b8efbca539129a9e60dd47db16325",
@@ -215,7 +220,7 @@
         }
     ],
     "wof:id":1108794057,
-    "wof:lastmodified":1694493374,
+    "wof:lastmodified":1695886616,
     "wof:name":"Shannan",
     "wof:parent_id":85669747,
     "wof:placetype":"county",

--- a/data/110/879/405/9/1108794059.geojson
+++ b/data/110/879/405/9/1108794059.geojson
@@ -94,8 +94,13 @@
     "wof:concordances":{
         "gn:id":1790468,
         "hasc:id":"CN.HN.XX",
+        "meso:local_id":"73843905",
         "qs_pg:id":1027507
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055780,
     "wof:geomhash":"7d6130a43ec84dd3316eaacd1eb39609",
@@ -109,7 +114,7 @@
         }
     ],
     "wof:id":1108794059,
-    "wof:lastmodified":1694493393,
+    "wof:lastmodified":1695886507,
     "wof:name":"Xiangxi",
     "wof:parent_id":85669781,
     "wof:placetype":"county",

--- a/data/110/879/406/1/1108794061.geojson
+++ b/data/110/879/406/1/1108794061.geojson
@@ -109,8 +109,13 @@
     "wof:concordances":{
         "gn:id":1803984,
         "hasc:id":"CN.SC.LI",
+        "meso:local_id":"73843731",
         "qs_pg:id":1031569
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055781,
     "wof:geomhash":"4a664b81f07ee50aead046d4825467f2",
@@ -124,7 +129,7 @@
         }
     ],
     "wof:id":1108794061,
-    "wof:lastmodified":1694493374,
+    "wof:lastmodified":1695886615,
     "wof:name":"Liangshan",
     "wof:parent_id":85669787,
     "wof:placetype":"county",

--- a/data/110/879/406/3/1108794063.geojson
+++ b/data/110/879/406/3/1108794063.geojson
@@ -95,8 +95,13 @@
     "wof:concordances":{
         "gn:id":1808130,
         "hasc:id":"CN.YN.HH",
+        "meso:local_id":"73843942",
         "qs_pg:id":372237
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055842,
     "wof:geomhash":"e86980941fa664e2c1adfc09ff609f10",
@@ -110,7 +115,7 @@
         }
     ],
     "wof:id":1108794063,
-    "wof:lastmodified":1694493392,
+    "wof:lastmodified":1695886503,
     "wof:name":"Honghe Hanizu",
     "wof:parent_id":85669791,
     "wof:placetype":"county",

--- a/data/110/879/406/5/1108794065.geojson
+++ b/data/110/879/406/5/1108794065.geojson
@@ -206,9 +206,14 @@
     "wof:concordances":{
         "gn:id":1818175,
         "hasc:id":"CN.SC.AB",
+        "meso:local_id":"73844017",
         "qs_pg:id":1027740,
         "wd:id":"Q304182"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055852,
     "wof:geomhash":"b8d3565deb116ac6951d0c20da91368d",
@@ -222,7 +227,7 @@
         }
     ],
     "wof:id":1108794065,
-    "wof:lastmodified":1694493374,
+    "wof:lastmodified":1695886616,
     "wof:name":"Aba",
     "wof:parent_id":85669787,
     "wof:placetype":"county",

--- a/data/110/879/406/7/1108794067.geojson
+++ b/data/110/879/406/7/1108794067.geojson
@@ -101,8 +101,13 @@
     "wof:concordances":{
         "gn:id":1798360,
         "hasc:id":"CN.GZ.QD",
+        "meso:local_id":"73844039",
         "qs_pg:id":372154
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055840,
     "wof:geomhash":"3c269f752edd785a6246a153fa29b863",
@@ -116,7 +121,7 @@
         }
     ],
     "wof:id":1108794067,
-    "wof:lastmodified":1694493392,
+    "wof:lastmodified":1695886504,
     "wof:name":"Qiandongnan",
     "wof:parent_id":85669781,
     "wof:placetype":"county",

--- a/data/110/879/407/1/1108794071.geojson
+++ b/data/110/879/407/1/1108794071.geojson
@@ -166,8 +166,13 @@
     "wof:concordances":{
         "gn:id":1810686,
         "hasc:id":"CN.GS.GN",
+        "meso:local_id":"73843925",
         "qs_pg:id":244488
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055994,
     "wof:geomhash":"0362883f93612be08d6057087ada600f",
@@ -181,7 +186,7 @@
         }
     ],
     "wof:id":1108794071,
-    "wof:lastmodified":1694493396,
+    "wof:lastmodified":1695886126,
     "wof:name":"Gannan",
     "wof:parent_id":85669711,
     "wof:placetype":"county",

--- a/data/856/697/11/85669711.geojson
+++ b/data/856/697/11/85669711.geojson
@@ -508,6 +508,7 @@
         "gn:id":1810676,
         "gp:id":12578005,
         "hasc:id":"CN.GS",
+        "iso:code":"CN-GS",
         "iso:id":"CN-GS",
         "loc:id":"n81022588",
         "qs_pg:id":17592,
@@ -515,6 +516,7 @@
         "wd:id":"Q42392",
         "wk:page":"Gansu"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -540,7 +542,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493410,
+    "wof:lastmodified":1695884426,
     "wof:name":"Gansu",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/697/15/85669715.geojson
+++ b/data/856/697/15/85669715.geojson
@@ -480,6 +480,7 @@
         "gn:id":1280239,
         "gp:id":12577996,
         "hasc:id":"CN.QH",
+        "iso:code":"CN-QH",
         "iso:id":"CN-QH",
         "loc:id":"n81015718",
         "qs_pg:id":1115219,
@@ -487,6 +488,7 @@
         "wd:id":"Q45833",
         "wk:page":"Qinghai"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -512,7 +514,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493417,
+    "wof:lastmodified":1695884432,
     "wof:name":"Qinghai",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/697/17/85669717.geojson
+++ b/data/856/697/17/85669717.geojson
@@ -505,11 +505,13 @@
         "gn:id":1809867,
         "gp:id":12578006,
         "hasc:id":"CN.GX",
+        "iso:code":"CN-GX",
         "iso:id":"CN-GX",
         "qs_pg:id":1156107,
         "unlc:id":"CN-45",
         "wd:id":"Q15176"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -535,7 +537,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493412,
+    "wof:lastmodified":1695884427,
     "wof:name":"Guangxi Zhuang",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/697/21/85669721.geojson
+++ b/data/856/697/21/85669721.geojson
@@ -486,6 +486,7 @@
         "gn:id":1809445,
         "gp:id":12578007,
         "hasc:id":"CN.GZ",
+        "iso:code":"CN-GZ",
         "iso:id":"CN-GZ",
         "loc:id":"n81026035",
         "qs_pg:id":895654,
@@ -493,6 +494,7 @@
         "wd:id":"Q47097",
         "wk:page":"Guizhou"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -518,7 +520,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493412,
+    "wof:lastmodified":1695884428,
     "wof:name":"Guizhou",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/697/25/85669725.geojson
+++ b/data/856/697/25/85669725.geojson
@@ -586,11 +586,13 @@
         "gn:id":1814905,
         "gp:id":20070171,
         "hasc:id":"CN.CQ",
+        "iso:code":"CN-CQ",
         "iso:id":"CN-CQ",
         "qs_pg:id":241362,
         "unlc:id":"CN-50",
         "wd:id":"Q11725"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -616,7 +618,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493419,
+    "wof:lastmodified":1695884434,
     "wof:name":"Chongqing",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/697/27/85669727.geojson
+++ b/data/856/697/27/85669727.geojson
@@ -878,11 +878,13 @@
         "gn:id":2038349,
         "gp:id":12578011,
         "hasc:id":"CN.BJ",
+        "iso:code":"CN-BJ",
         "iso:id":"CN-BJ",
         "qs_pg:id":851886,
         "unlc:id":"CN-11",
         "wd:id":"Q956"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         102027745
     ],
@@ -911,7 +913,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493410,
+    "wof:lastmodified":1695884426,
     "wof:name":"Beijing",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/697/35/85669735.geojson
+++ b/data/856/697/35/85669735.geojson
@@ -478,6 +478,7 @@
         "gn:id":1811017,
         "gp:id":12577997,
         "hasc:id":"CN.FJ",
+        "iso:code":"CN-FJ",
         "iso:id":"CN-FJ",
         "loc:id":"n80113116",
         "qs_pg:id":1156105,
@@ -485,6 +486,7 @@
         "wd:id":"Q41705",
         "wk:page":"Fujian"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -510,7 +512,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493410,
+    "wof:lastmodified":1695884425,
     "wof:name":"Fujian",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/697/39/85669739.geojson
+++ b/data/856/697/39/85669739.geojson
@@ -501,6 +501,7 @@
         "gn:id":1818058,
         "gp:id":12578022,
         "hasc:id":"CN.AH",
+        "iso:code":"CN-AH",
         "iso:id":"CN-AH",
         "loc:id":"n81066245",
         "qs_pg:id":1249010,
@@ -508,6 +509,7 @@
         "wd:id":"Q40956",
         "wk:page":"Anhui"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -533,7 +535,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493416,
+    "wof:lastmodified":1695884431,
     "wof:name":"Anhui",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/697/43/85669743.geojson
+++ b/data/856/697/43/85669743.geojson
@@ -500,6 +500,7 @@
         "gn:id":1809935,
         "gp:id":12578019,
         "hasc:id":"CN.GD",
+        "iso:code":"CN-GD",
         "iso:id":"CN-GD",
         "loc:id":"n81018335",
         "nyt:id":"N59168527706025732091",
@@ -508,6 +509,7 @@
         "wd:id":"Q15175",
         "wk:page":"Guangdong"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -533,7 +535,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493426,
+    "wof:lastmodified":1695884955,
     "wof:name":"Guangdong",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/697/47/85669747.geojson
+++ b/data/856/697/47/85669747.geojson
@@ -345,6 +345,7 @@
         "gn:id":1279685,
         "gp:id":12578004,
         "hasc:id":"CN.XZ",
+        "iso:code":"CN-XZ",
         "iso:id":"CN-XZ",
         "loc:id":"n79100917",
         "nyt:id":"51603260610445312001",
@@ -353,6 +354,7 @@
         "wd:id":"Q17269",
         "wk:page":"Tibet Autonomous Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "meso"
@@ -378,7 +380,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493418,
+    "wof:lastmodified":1695884433,
     "wof:name":"Tibet",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/697/53/85669753.geojson
+++ b/data/856/697/53/85669753.geojson
@@ -558,6 +558,7 @@
         "gn:id":1529047,
         "gp:id":12578003,
         "hasc:id":"CN.XJ",
+        "iso:code":"CN-XJ",
         "iso:id":"CN-XJ",
         "loc:id":"n81018776",
         "qs_pg:id":931671,
@@ -565,6 +566,7 @@
         "wd:id":"Q34800",
         "wk:page":"Xinjiang"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "meso",
@@ -591,7 +593,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493414,
+    "wof:lastmodified":1695884429,
     "wof:name":"Xinjiang Uyghur",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/697/59/85669759.geojson
+++ b/data/856/697/59/85669759.geojson
@@ -552,12 +552,14 @@
         "gn:id":1809054,
         "gp:id":12578020,
         "hasc:id":"CN.HA",
+        "iso:code":"CN-HI",
         "iso:id":"CN-HI",
         "loc:id":"n88080551",
         "qs_pg:id":931674,
         "wd:id":"Q42200",
         "wk:page":"Hainan"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -582,7 +584,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493409,
+    "wof:lastmodified":1695884425,
     "wof:name":"Hainan",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/856/697/63/85669763.geojson
+++ b/data/856/697/63/85669763.geojson
@@ -493,12 +493,14 @@
         "gn:id":1799355,
         "gp:id":12578010,
         "hasc:id":"CN.NX",
+        "iso:code":"CN-NX",
         "iso:id":"CN-NX",
         "qs_pg:id":1285870,
         "unlc:id":"CN-64",
         "wd:id":"Q57448",
         "wk:page":"Ningxia"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -524,7 +526,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493417,
+    "wof:lastmodified":1695884432,
     "wof:name":"Ningxia Hui",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/697/69/85669769.geojson
+++ b/data/856/697/69/85669769.geojson
@@ -498,11 +498,13 @@
         "gn:id":1796480,
         "gp:id":12578015,
         "hasc:id":"CN.SA",
+        "iso:code":"CN-SN",
         "iso:id":"CN-SN",
         "qs_pg:id":851891,
         "unlc:id":"CN-61",
         "wd:id":"Q47974"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -528,7 +530,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493410,
+    "wof:lastmodified":1695884426,
     "wof:name":"Shaanxi",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/697/73/85669773.geojson
+++ b/data/856/697/73/85669773.geojson
@@ -492,6 +492,7 @@
         "gn:id":1795912,
         "gp:id":12578013,
         "hasc:id":"CN.SX",
+        "iso:code":"CN-SX",
         "iso:id":"CN-SX",
         "loc:id":"n80131727",
         "qs_pg:id":422887,
@@ -499,6 +500,7 @@
         "wd:id":"Q46913",
         "wk:page":"Shanxi"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -524,7 +526,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493411,
+    "wof:lastmodified":1695884427,
     "wof:name":"Shanxi",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/697/77/85669777.geojson
+++ b/data/856/697/77/85669777.geojson
@@ -503,6 +503,7 @@
         "gn:id":1806949,
         "gp:id":12578002,
         "hasc:id":"CN.HU",
+        "iso:code":"CN-HB",
         "iso:id":"CN-HB",
         "loc:id":"n81018205",
         "qs_pg:id":372232,
@@ -510,6 +511,7 @@
         "wd:id":"Q46862",
         "wk:page":"Hubei"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -535,7 +537,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493417,
+    "wof:lastmodified":1695884432,
     "wof:name":"Hubei",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/697/81/85669781.geojson
+++ b/data/856/697/81/85669781.geojson
@@ -479,6 +479,7 @@
         "gn:id":1806691,
         "gp:id":12578001,
         "hasc:id":"CN.HN",
+        "iso:code":"CN-HN",
         "iso:id":"CN-HN",
         "loc:id":"n79064833",
         "qs_pg:id":372217,
@@ -486,6 +487,7 @@
         "wd:id":"Q45761",
         "wk:page":"Hunan"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -511,7 +513,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493413,
+    "wof:lastmodified":1695884428,
     "wof:name":"Hunan",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/697/87/85669787.geojson
+++ b/data/856/697/87/85669787.geojson
@@ -534,6 +534,7 @@
         "gn:id":1794299,
         "gp:id":12578016,
         "hasc:id":"CN.SC",
+        "iso:code":"CN-SC",
         "iso:id":"CN-SC",
         "loc:id":"n81020323",
         "nyt:id":"N2943438798431491821",
@@ -542,6 +543,7 @@
         "wd:id":"Q19770",
         "wk:page":"Sichuan"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -567,7 +569,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493411,
+    "wof:lastmodified":1695884427,
     "wof:name":"Sichuan",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/697/91/85669791.geojson
+++ b/data/856/697/91/85669791.geojson
@@ -489,6 +489,7 @@
         "gn:id":1785694,
         "gp:id":12578018,
         "hasc:id":"CN.YN",
+        "iso:code":"CN-YN",
         "iso:id":"CN-YN",
         "loc:id":"n81059860",
         "nyt:id":"N1054741059483811661",
@@ -497,6 +498,7 @@
         "wd:id":"Q43194",
         "wk:page":"Yunnan"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -522,7 +524,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493413,
+    "wof:lastmodified":1695884428,
     "wof:name":"Yunnan",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/697/97/85669797.geojson
+++ b/data/856/697/97/85669797.geojson
@@ -488,6 +488,7 @@
         "gn:id":1808773,
         "gp:id":12578000,
         "hasc:id":"CN.HB",
+        "iso:code":"CN-HE",
         "iso:id":"CN-HE",
         "loc:id":"n81108669",
         "qs_pg:id":1156109,
@@ -495,6 +496,7 @@
         "wd:id":"Q21208",
         "wk:page":"Hebei"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -520,7 +522,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493416,
+    "wof:lastmodified":1695884432,
     "wof:name":"Hebei",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/698/01/85669801.geojson
+++ b/data/856/698/01/85669801.geojson
@@ -480,6 +480,7 @@
         "gn:id":1808520,
         "gp:id":12577999,
         "hasc:id":"CN.HE",
+        "iso:code":"CN-HA",
         "iso:id":"CN-HA",
         "loc:id":"n2010042254",
         "qs_pg:id":1115220,
@@ -487,6 +488,7 @@
         "wd:id":"Q43684",
         "wk:page":"Henan"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -512,7 +514,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493422,
+    "wof:lastmodified":1695884436,
     "wof:name":"Henan",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/698/07/85669807.geojson
+++ b/data/856/698/07/85669807.geojson
@@ -494,6 +494,7 @@
         "gn:id":2036115,
         "gp:id":12578008,
         "hasc:id":"CN.LN",
+        "iso:code":"CN-LN",
         "iso:id":"CN-LN",
         "loc:id":"n80138224",
         "qs_pg:id":895655,
@@ -501,6 +502,7 @@
         "wd:id":"Q43934",
         "wk:page":"Liaoning"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -526,7 +528,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493421,
+    "wof:lastmodified":1695884436,
     "wof:name":"Liaoning",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/698/13/85669813.geojson
+++ b/data/856/698/13/85669813.geojson
@@ -499,6 +499,7 @@
         "gn:id":1796328,
         "gp:id":12578014,
         "hasc:id":"CN.SD",
+        "iso:code":"CN-SD",
         "iso:id":"CN-SD",
         "loc:id":"n80158871",
         "qs_pg:id":931672,
@@ -506,6 +507,7 @@
         "wd:id":"Q43407",
         "wk:page":"Shandong"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -531,7 +533,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493424,
+    "wof:lastmodified":1695884438,
     "wof:name":"Shandong",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/698/17/85669817.geojson
+++ b/data/856/698/17/85669817.geojson
@@ -606,11 +606,13 @@
         "gn:id":1792943,
         "gp:id":12578017,
         "hasc:id":"CN.TJ",
+        "iso:code":"CN-TJ",
         "iso:id":"CN-TJ",
         "qs_pg:id":1115784,
         "unlc:id":"CN-12",
         "wd:id":"Q11736"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -636,7 +638,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493420,
+    "wof:lastmodified":1695884435,
     "wof:name":"Tianjin",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/698/23/85669823.geojson
+++ b/data/856/698/23/85669823.geojson
@@ -468,6 +468,7 @@
         "gn:id":1806222,
         "gp:id":12577993,
         "hasc:id":"CN.JX",
+        "iso:code":"CN-JX",
         "iso:id":"CN-JX",
         "loc:id":"n79128971",
         "qs_pg:id":1115217,
@@ -475,6 +476,7 @@
         "wd:id":"Q57052",
         "wk:page":"Jiangxi"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -500,7 +502,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493422,
+    "wof:lastmodified":1695884437,
     "wof:name":"Jiangxi",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/698/27/85669827.geojson
+++ b/data/856/698/27/85669827.geojson
@@ -483,6 +483,7 @@
         "gn:id":1806260,
         "gp:id":12577994,
         "hasc:id":"CN.JS",
+        "iso:code":"CN-JS",
         "iso:id":"CN-JS",
         "loc:id":"n81022196",
         "qs_pg:id":885459,
@@ -490,6 +491,7 @@
         "wd:id":"Q16963",
         "wk:page":"Jiangsu"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -515,7 +517,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493420,
+    "wof:lastmodified":1695884434,
     "wof:name":"Jiangsu",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/698/31/85669831.geojson
+++ b/data/856/698/31/85669831.geojson
@@ -748,11 +748,13 @@
         "gn:id":1796231,
         "gp:id":12578012,
         "hasc:id":"CN.SH",
+        "iso:code":"CN-SH",
         "iso:id":"CN-SH",
         "qs_pg:id":851887,
         "unlc:id":"CN-31",
         "wd:id":"Q8686"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -778,7 +780,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493422,
+    "wof:lastmodified":1695884436,
     "wof:name":"Shanghai",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/698/35/85669835.geojson
+++ b/data/856/698/35/85669835.geojson
@@ -479,6 +479,7 @@
         "gn:id":1784764,
         "gp:id":12577992,
         "hasc:id":"CN.ZJ",
+        "iso:code":"CN-ZJ",
         "iso:id":"CN-ZJ",
         "loc:id":"n81023097",
         "qs_pg:id":1156101,
@@ -486,6 +487,7 @@
         "wd:id":"Q16967",
         "wk:page":"Zhejiang"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -511,7 +513,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493419,
+    "wof:lastmodified":1695884434,
     "wof:name":"Zhejiang",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/698/43/85669843.geojson
+++ b/data/856/698/43/85669843.geojson
@@ -480,6 +480,7 @@
         "gn:id":2036500,
         "gp:id":12577995,
         "hasc:id":"CN.JL",
+        "iso:code":"CN-JL",
         "iso:id":"CN-JL",
         "loc:id":"n81019981",
         "qs_pg:id":1115218,
@@ -487,6 +488,7 @@
         "wd:id":"Q45208",
         "wk:page":"Jilin"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -512,7 +514,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493420,
+    "wof:lastmodified":1695884435,
     "wof:name":"Jilin",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/698/47/85669847.geojson
+++ b/data/856/698/47/85669847.geojson
@@ -516,12 +516,14 @@
         "gn:id":2035607,
         "gp:id":12578009,
         "hasc:id":"CN.NM",
+        "iso:code":"CN-NM",
         "iso:id":"CN-NM",
         "loc:id":"n81018477",
         "qs_pg:id":1028384,
         "wd:id":"Q41079",
         "wk:page":"Inner Mongolia"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -547,7 +549,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493423,
+    "wof:lastmodified":1695884438,
     "wof:name":"Inner Mongolia",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/698/49/85669849.geojson
+++ b/data/856/698/49/85669849.geojson
@@ -463,6 +463,7 @@
         "gn:id":2036965,
         "gp:id":12577998,
         "hasc:id":"CN.HL",
+        "iso:code":"CN-HL",
         "iso:id":"CN-HL",
         "loc:id":"n81071016",
         "qs_pg:id":372769,
@@ -470,6 +471,7 @@
         "wd:id":"Q19206",
         "wk:page":"Heilongjiang"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -495,7 +497,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493423,
+    "wof:lastmodified":1695884437,
     "wof:name":"Heilongjiang",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/856/813/27/85681327.geojson
+++ b/data/856/813/27/85681327.geojson
@@ -334,7 +334,7 @@
         "bod",
         "kor"
     ],
-    "wof:lastmodified":1694493409,
+    "wof:lastmodified":1695884289,
     "wof:name":"Paracel Islands",
     "wof:parent_id":85632695,
     "wof:placetype":"region",

--- a/data/890/511/835/890511835.geojson
+++ b/data/890/511/835/890511835.geojson
@@ -138,10 +138,15 @@
     "wof:concordances":{
         "gn:id":1810636,
         "hasc:id":"CN.JX.GZ",
+        "meso:local_id":"73843974",
         "qs_pg:id":244487,
         "wd:id":"Q1356759",
         "wk:page":"Xingguo County"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055747,
     "wof:geom_alt":[
@@ -158,7 +163,7 @@
         }
     ],
     "wof:id":890511835,
-    "wof:lastmodified":1694493389,
+    "wof:lastmodified":1695886495,
     "wof:name":"Ganzhou",
     "wof:parent_id":85669823,
     "wof:placetype":"county",

--- a/data/890/511/853/890511853.geojson
+++ b/data/890/511/853/890511853.geojson
@@ -187,8 +187,13 @@
     "wof:concordances":{
         "gn:id":1800145,
         "hasc:id":"CN.SC.NC",
+        "meso:local_id":"73843737",
         "qs_pg:id":1152049
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055748,
     "wof:geom_alt":[
@@ -205,7 +210,7 @@
         }
     ],
     "wof:id":890511853,
-    "wof:lastmodified":1694493400,
+    "wof:lastmodified":1695886135,
     "wof:name":"Nanchong",
     "wof:parent_id":85669787,
     "wof:placetype":"county",

--- a/data/890/511/873/890511873.geojson
+++ b/data/890/511/873/890511873.geojson
@@ -159,9 +159,14 @@
         "gn:id":1788045,
         "gp:id":26198372,
         "hasc:id":"CN.HE.XC",
+        "meso:local_id":"73843969",
         "qs_pg:id":270557,
         "wd:id":"Q1198806"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055749,
     "wof:geom_alt":[
@@ -178,7 +183,7 @@
         }
     ],
     "wof:id":890511873,
-    "wof:lastmodified":1694493400,
+    "wof:lastmodified":1695886136,
     "wof:name":"Xuchang",
     "wof:parent_id":85669801,
     "wof:placetype":"county",

--- a/data/890/511/887/890511887.geojson
+++ b/data/890/511/887/890511887.geojson
@@ -229,8 +229,13 @@
         "gn:id":1808961,
         "gp:id":26198254,
         "hasc:id":"CN.HB.HD",
+        "meso:local_id":"73843988",
         "qs_pg:id":271809
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055750,
     "wof:geom_alt":[
@@ -247,7 +252,7 @@
         }
     ],
     "wof:id":890511887,
-    "wof:lastmodified":1694493400,
+    "wof:lastmodified":1695886135,
     "wof:name":"Handan",
     "wof:parent_id":85669797,
     "wof:placetype":"county",

--- a/data/890/511/937/890511937.geojson
+++ b/data/890/511/937/890511937.geojson
@@ -184,8 +184,13 @@
     "wof:concordances":{
         "gn:id":1791635,
         "hasc:id":"CN.SA.WN",
+        "meso:local_id":"73843902",
         "qs_pg:id":372065
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055752,
     "wof:geom_alt":[
@@ -202,7 +207,7 @@
         }
     ],
     "wof:id":890511937,
-    "wof:lastmodified":1694493400,
+    "wof:lastmodified":1695886135,
     "wof:name":"Weinan",
     "wof:parent_id":85669769,
     "wof:placetype":"county",

--- a/data/890/512/033/890512033.geojson
+++ b/data/890/512/033/890512033.geojson
@@ -190,8 +190,13 @@
     "wof:concordances":{
         "gn:id":1785551,
         "hasc:id":"CN.YN.YX",
+        "meso:local_id":"73843921",
         "qs_pg:id":1031427
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055755,
     "wof:geom_alt":[
@@ -208,7 +213,7 @@
         }
     ],
     "wof:id":890512033,
-    "wof:lastmodified":1694493405,
+    "wof:lastmodified":1695886151,
     "wof:name":"Yuxi",
     "wof:parent_id":85669791,
     "wof:placetype":"county",

--- a/data/890/512/205/890512205.geojson
+++ b/data/890/512/205/890512205.geojson
@@ -178,8 +178,13 @@
     "wof:concordances":{
         "gn:id":1793770,
         "hasc:id":"CN.JS.SQ",
+        "meso:local_id":"73843797",
         "qs_pg:id":351109
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055762,
     "wof:geom_alt":[
@@ -196,7 +201,7 @@
         }
     ],
     "wof:id":890512205,
-    "wof:lastmodified":1694493383,
+    "wof:lastmodified":1695886059,
     "wof:name":"Suqian",
     "wof:parent_id":85669827,
     "wof:placetype":"county",

--- a/data/890/512/239/890512239.geojson
+++ b/data/890/512/239/890512239.geojson
@@ -202,8 +202,13 @@
     "wof:concordances":{
         "gn:id":1788527,
         "hasc:id":"CN.HE.XY",
+        "meso:local_id":"73843722",
         "qs_pg:id":276564
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055763,
     "wof:geom_alt":[
@@ -220,7 +225,7 @@
         }
     ],
     "wof:id":890512239,
-    "wof:lastmodified":1694493405,
+    "wof:lastmodified":1695886151,
     "wof:name":"Xinyang",
     "wof:parent_id":85669801,
     "wof:placetype":"county",

--- a/data/890/512/639/890512639.geojson
+++ b/data/890/512/639/890512639.geojson
@@ -170,8 +170,13 @@
     "wof:concordances":{
         "gp:id":26198180,
         "hasc:id":"CN.GX.FC",
+        "meso:local_id":"73844012",
         "qs_pg:id":911186
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055779,
     "wof:geom_alt":[
@@ -188,7 +193,7 @@
         }
     ],
     "wof:id":890512639,
-    "wof:lastmodified":1694493384,
+    "wof:lastmodified":1695886060,
     "wof:name":"Fangchenggang",
     "wof:parent_id":85669717,
     "wof:placetype":"county",

--- a/data/890/512/655/890512655.geojson
+++ b/data/890/512/655/890512655.geojson
@@ -202,8 +202,13 @@
     "wof:concordances":{
         "gn:id":1798826,
         "hasc:id":"CN.HE.PD",
+        "meso:local_id":"73843808",
         "qs_pg:id":1027579
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055779,
     "wof:geom_alt":[
@@ -220,7 +225,7 @@
         }
     ],
     "wof:id":890512655,
-    "wof:lastmodified":1694493406,
+    "wof:lastmodified":1695886151,
     "wof:name":"Pingdingshan",
     "wof:parent_id":85669801,
     "wof:placetype":"county",

--- a/data/890/512/711/890512711.geojson
+++ b/data/890/512/711/890512711.geojson
@@ -181,8 +181,13 @@
     "wof:concordances":{
         "gn:id":1804151,
         "hasc:id":"CN.SC.LS",
+        "meso:local_id":"73843708",
         "qs_pg:id":1062522
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055782,
     "wof:geom_alt":[
@@ -199,7 +204,7 @@
         }
     ],
     "wof:id":890512711,
-    "wof:lastmodified":1694493406,
+    "wof:lastmodified":1695886151,
     "wof:name":"Leshan",
     "wof:parent_id":85669787,
     "wof:placetype":"county",

--- a/data/890/512/733/890512733.geojson
+++ b/data/890/512/733/890512733.geojson
@@ -148,8 +148,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":6643239,
+        "meso:local_id":"73843694",
         "qs_pg:id":1153568
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1469055783,
     "wof:geom_alt":[
@@ -166,7 +168,7 @@
         }
     ],
     "wof:id":890512733,
-    "wof:lastmodified":1694493384,
+    "wof:lastmodified":1695886060,
     "wof:name":"Zhongwei",
     "wof:parent_id":85669763,
     "wof:placetype":"county",

--- a/data/890/512/741/890512741.geojson
+++ b/data/890/512/741/890512741.geojson
@@ -184,8 +184,13 @@
     "wof:concordances":{
         "gn:id":6643372,
         "hasc:id":"CN.SC.GY",
+        "meso:local_id":"73843809",
         "qs_pg:id":1153572
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055783,
     "wof:geom_alt":[
@@ -202,7 +207,7 @@
         }
     ],
     "wof:id":890512741,
-    "wof:lastmodified":1694493405,
+    "wof:lastmodified":1695886150,
     "wof:name":"Guangyuan",
     "wof:parent_id":85669787,
     "wof:placetype":"county",

--- a/data/890/512/761/890512761.geojson
+++ b/data/890/512/761/890512761.geojson
@@ -181,8 +181,13 @@
     "wof:concordances":{
         "gn:id":1785723,
         "hasc:id":"CN.GD.YF",
+        "meso:local_id":"73843710",
         "qs_pg:id":1152037
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055784,
     "wof:geom_alt":[
@@ -199,7 +204,7 @@
         }
     ],
     "wof:id":890512761,
-    "wof:lastmodified":1694493384,
+    "wof:lastmodified":1695886060,
     "wof:name":"Yunfu",
     "wof:parent_id":85669743,
     "wof:placetype":"county",

--- a/data/890/512/763/890512763.geojson
+++ b/data/890/512/763/890512763.geojson
@@ -178,8 +178,13 @@
     "wof:concordances":{
         "gn:id":6587798,
         "hasc:id":"CN.JL.SY",
+        "meso:local_id":"73843859",
         "qs_pg:id":1153505
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055784,
     "wof:geom_alt":[
@@ -196,7 +201,7 @@
         }
     ],
     "wof:id":890512763,
-    "wof:lastmodified":1694493405,
+    "wof:lastmodified":1695886149,
     "wof:name":"Songyuan",
     "wof:parent_id":85669843,
     "wof:placetype":"county",

--- a/data/890/512/833/890512833.geojson
+++ b/data/890/512/833/890512833.geojson
@@ -190,8 +190,13 @@
     "wof:concordances":{
         "gn:id":1790838,
         "hasc:id":"CN.GX.WZ",
+        "meso:local_id":"73843867",
         "qs_pg:id":372046
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055788,
     "wof:geom_alt":[
@@ -208,7 +213,7 @@
         }
     ],
     "wof:id":890512833,
-    "wof:lastmodified":1694493405,
+    "wof:lastmodified":1695886150,
     "wof:name":"Wuzhou",
     "wof:parent_id":85669717,
     "wof:placetype":"county",

--- a/data/890/512/845/890512845.geojson
+++ b/data/890/512/845/890512845.geojson
@@ -181,8 +181,13 @@
     "wof:concordances":{
         "gn:id":1797652,
         "hasc:id":"CN.GS.QY",
+        "meso:local_id":"73843812",
         "qs_pg:id":372114
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055788,
     "wof:geom_alt":[
@@ -199,7 +204,7 @@
         }
     ],
     "wof:id":890512845,
-    "wof:lastmodified":1694493383,
+    "wof:lastmodified":1695886059,
     "wof:name":"Qingyang",
     "wof:parent_id":85669711,
     "wof:placetype":"county",

--- a/data/890/512/867/890512867.geojson
+++ b/data/890/512/867/890512867.geojson
@@ -235,8 +235,13 @@
     "wof:concordances":{
         "gn:id":2038431,
         "hasc:id":"CN.NM.BT",
+        "meso:local_id":"73843732",
         "qs_pg:id":1028406
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055789,
     "wof:geom_alt":[
@@ -253,7 +258,7 @@
         }
     ],
     "wof:id":890512867,
-    "wof:lastmodified":1694493405,
+    "wof:lastmodified":1695886150,
     "wof:name":"Baotou",
     "wof:parent_id":85669847,
     "wof:placetype":"county",

--- a/data/890/512/869/890512869.geojson
+++ b/data/890/512/869/890512869.geojson
@@ -193,8 +193,13 @@
     "wof:concordances":{
         "gn:id":2038567,
         "hasc:id":"CN.JL.BC",
+        "meso:local_id":"73843927",
         "qs_pg:id":1028407
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055789,
     "wof:geom_alt":[
@@ -211,7 +216,7 @@
         }
     ],
     "wof:id":890512869,
-    "wof:lastmodified":1694639806,
+    "wof:lastmodified":1695886150,
     "wof:name":"Baicheng",
     "wof:parent_id":85669843,
     "wof:placetype":"county",

--- a/data/890/513/007/890513007.geojson
+++ b/data/890/513/007/890513007.geojson
@@ -208,8 +208,13 @@
     "wof:concordances":{
         "gn:id":2037847,
         "hasc:id":"CN.HL.DQ",
+        "meso:local_id":"73843773",
         "qs_pg:id":1243602
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055797,
     "wof:geom_alt":[
@@ -226,7 +231,7 @@
         }
     ],
     "wof:id":890513007,
-    "wof:lastmodified":1694493404,
+    "wof:lastmodified":1695886147,
     "wof:name":"Daqing",
     "wof:parent_id":85669849,
     "wof:placetype":"county",

--- a/data/890/513/011/890513011.geojson
+++ b/data/890/513/011/890513011.geojson
@@ -235,8 +235,13 @@
         "gn:id":2037353,
         "gp:id":26198075,
         "hasc:id":"CN.LN.FS",
+        "meso:local_id":"73843833",
         "qs_pg:id":1201236
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055797,
     "wof:geom_alt":[
@@ -253,7 +258,7 @@
         }
     ],
     "wof:id":890513011,
-    "wof:lastmodified":1694493382,
+    "wof:lastmodified":1695886056,
     "wof:name":"Fushun",
     "wof:parent_id":85669807,
     "wof:placetype":"county",

--- a/data/890/513/013/890513013.geojson
+++ b/data/890/513/013/890513013.geojson
@@ -304,8 +304,13 @@
         "gn:id":1804429,
         "gp:id":26198129,
         "hasc:id":"CN.GS.LZ",
+        "meso:local_id":"73843728",
         "qs_pg:id":203469
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055797,
     "wof:geom_alt":[
@@ -322,7 +327,7 @@
         }
     ],
     "wof:id":890513013,
-    "wof:lastmodified":1694493380,
+    "wof:lastmodified":1695886052,
     "wof:name":"Lanzhou",
     "wof:parent_id":85669711,
     "wof:placetype":"county",

--- a/data/890/513/015/890513015.geojson
+++ b/data/890/513/015/890513015.geojson
@@ -206,8 +206,13 @@
         "gn:id":1788925,
         "gp:id":26198360,
         "hasc:id":"CN.HB.XT",
+        "meso:local_id":"73843986",
         "qs_pg:id":206442
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055797,
     "wof:geom_alt":[
@@ -224,7 +229,7 @@
         }
     ],
     "wof:id":890513015,
-    "wof:lastmodified":1694493381,
+    "wof:lastmodified":1695886052,
     "wof:name":"Xingtai",
     "wof:parent_id":85669797,
     "wof:placetype":"county",

--- a/data/890/513/031/890513031.geojson
+++ b/data/890/513/031/890513031.geojson
@@ -187,8 +187,13 @@
         "gn:id":6642630,
         "gp:id":26198306,
         "hasc:id":"CN.SX.XZ",
+        "meso:local_id":"73843824",
         "qs_pg:id":212449
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055798,
     "wof:geom_alt":[
@@ -205,7 +210,7 @@
         }
     ],
     "wof:id":890513031,
-    "wof:lastmodified":1694493404,
+    "wof:lastmodified":1695886148,
     "wof:name":"Xinzhou",
     "wof:parent_id":85669773,
     "wof:placetype":"county",

--- a/data/890/513/033/890513033.geojson
+++ b/data/890/513/033/890513033.geojson
@@ -232,8 +232,13 @@
         "gn:id":1815394,
         "gp:id":26198242,
         "hasc:id":"CN.GD.CZ",
+        "meso:local_id":"73843913",
         "qs_pg:id":219972
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055798,
     "wof:geom_alt":[
@@ -250,7 +255,7 @@
         }
     ],
     "wof:id":890513033,
-    "wof:lastmodified":1694493405,
+    "wof:lastmodified":1695886149,
     "wof:name":"Chaozhou",
     "wof:parent_id":85669743,
     "wof:placetype":"county",

--- a/data/890/513/059/890513059.geojson
+++ b/data/890/513/059/890513059.geojson
@@ -220,8 +220,13 @@
         "gn:id":1808369,
         "gp:id":26198162,
         "hasc:id":"CN.HN.HY",
+        "meso:local_id":"73843963",
         "qs_pg:id":241516
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055799,
     "wof:geom_alt":[
@@ -238,7 +243,7 @@
         }
     ],
     "wof:id":890513059,
-    "wof:lastmodified":1694493404,
+    "wof:lastmodified":1695886148,
     "wof:name":"Hengyang",
     "wof:parent_id":85669781,
     "wof:placetype":"county",

--- a/data/890/513/063/890513063.geojson
+++ b/data/890/513/063/890513063.geojson
@@ -392,8 +392,13 @@
     "wof:concordances":{
         "gp:id":26198379,
         "hasc:id":"CN.CQ.CQ",
+        "meso:local_id":"73843995",
         "qs_pg:id":241683
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055799,
     "wof:geom_alt":[
@@ -410,7 +415,7 @@
         }
     ],
     "wof:id":890513063,
-    "wof:lastmodified":1694493381,
+    "wof:lastmodified":1695886053,
     "wof:name":"Chongqing",
     "wof:parent_id":85669725,
     "wof:placetype":"county",

--- a/data/890/513/075/890513075.geojson
+++ b/data/890/513/075/890513075.geojson
@@ -226,8 +226,13 @@
         "gn:id":1797593,
         "gp:id":26198365,
         "hasc:id":"CN.HB.QH",
+        "meso:local_id":"73843941",
         "qs_pg:id":1285219
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055799,
     "wof:geom_alt":[
@@ -244,7 +249,7 @@
         }
     ],
     "wof:id":890513075,
-    "wof:lastmodified":1694493382,
+    "wof:lastmodified":1695886056,
     "wof:name":"Qinhuangdao",
     "wof:parent_id":85669797,
     "wof:placetype":"county",

--- a/data/890/513/077/890513077.geojson
+++ b/data/890/513/077/890513077.geojson
@@ -235,8 +235,13 @@
         "gn:id":1817942,
         "gp:id":26198368,
         "hasc:id":"CN.HE.AY",
+        "meso:local_id":"73843787",
         "qs_pg:id":1285220
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055799,
     "wof:geom_alt":[
@@ -253,7 +258,7 @@
         }
     ],
     "wof:id":890513077,
-    "wof:lastmodified":1694493404,
+    "wof:lastmodified":1695886147,
     "wof:name":"Anyang",
     "wof:parent_id":85669801,
     "wof:placetype":"county",

--- a/data/890/513/083/890513083.geojson
+++ b/data/890/513/083/890513083.geojson
@@ -187,8 +187,13 @@
         "gn:id":1784107,
         "gp:id":26198143,
         "hasc:id":"CN.ZJ.ZS",
+        "meso:local_id":"73843949",
         "qs_pg:id":1193694
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055800,
     "wof:geom_alt":[
@@ -205,7 +210,7 @@
         }
     ],
     "wof:id":890513083,
-    "wof:lastmodified":1694493381,
+    "wof:lastmodified":1695886052,
     "wof:name":"Zhoushan",
     "wof:parent_id":85669835,
     "wof:placetype":"county",

--- a/data/890/513/085/890513085.geojson
+++ b/data/890/513/085/890513085.geojson
@@ -331,8 +331,13 @@
         "gn:id":1815551,
         "gp:id":26198213,
         "hasc:id":"CN.HN.CS",
+        "meso:local_id":"73844008",
         "qs_pg:id":1193747
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055800,
     "wof:geom_alt":[
@@ -349,7 +354,7 @@
         }
     ],
     "wof:id":890513085,
-    "wof:lastmodified":1694493381,
+    "wof:lastmodified":1695886053,
     "wof:name":"Changsha",
     "wof:parent_id":85669781,
     "wof:placetype":"county",

--- a/data/890/513/087/890513087.geojson
+++ b/data/890/513/087/890513087.geojson
@@ -445,8 +445,13 @@
         "gn:id":1809857,
         "gp:id":26198245,
         "hasc:id":"CN.GD.GZ",
+        "meso:local_id":"73843811",
         "qs_pg:id":1193760
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055800,
     "wof:geom_alt":[
@@ -463,7 +468,7 @@
         }
     ],
     "wof:id":890513087,
-    "wof:lastmodified":1694493382,
+    "wof:lastmodified":1695886056,
     "wof:name":"Guangzhou",
     "wof:parent_id":85669743,
     "wof:placetype":"county",

--- a/data/890/513/089/890513089.geojson
+++ b/data/890/513/089/890513089.geojson
@@ -259,8 +259,13 @@
         "gn:id":1811102,
         "gp:id":26198244,
         "hasc:id":"CN.GD.FS",
+        "meso:local_id":"73843717",
         "qs_pg:id":1193761
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055800,
     "wof:geom_alt":[
@@ -277,7 +282,7 @@
         }
     ],
     "wof:id":890513089,
-    "wof:lastmodified":1694493382,
+    "wof:lastmodified":1695886055,
     "wof:name":"Foshan",
     "wof:parent_id":85669743,
     "wof:placetype":"county",

--- a/data/890/513/093/890513093.geojson
+++ b/data/890/513/093/890513093.geojson
@@ -226,8 +226,13 @@
         "gn:id":1791227,
         "gp:id":26198332,
         "hasc:id":"CN.AH.WH",
+        "meso:local_id":"73843950",
         "qs_pg:id":1193845
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055800,
     "wof:geom_alt":[
@@ -244,7 +249,7 @@
         }
     ],
     "wof:id":890513093,
-    "wof:lastmodified":1694493405,
+    "wof:lastmodified":1695886149,
     "wof:name":"Wuhu",
     "wof:parent_id":85669739,
     "wof:placetype":"county",

--- a/data/890/513/095/890513095.geojson
+++ b/data/890/513/095/890513095.geojson
@@ -238,8 +238,13 @@
         "gn:id":1816969,
         "gp:id":26198364,
         "hasc:id":"CN.HB.BD",
+        "meso:local_id":"73843720",
         "qs_pg:id":1193883
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055800,
     "wof:geom_alt":[
@@ -256,7 +261,7 @@
         }
     ],
     "wof:id":890513095,
-    "wof:lastmodified":1694493382,
+    "wof:lastmodified":1695886057,
     "wof:name":"Baoding",
     "wof:parent_id":85669797,
     "wof:placetype":"county",

--- a/data/890/513/103/890513103.geojson
+++ b/data/890/513/103/890513103.geojson
@@ -163,8 +163,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":29281936,
+        "meso:local_id":"73843801",
         "qs_pg:id":1197557
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1469055801,
     "wof:geom_alt":[
@@ -181,7 +183,7 @@
         }
     ],
     "wof:id":890513103,
-    "wof:lastmodified":1694493380,
+    "wof:lastmodified":1695886051,
     "wof:name":"Chongzuo",
     "wof:parent_id":85669717,
     "wof:placetype":"county",

--- a/data/890/513/267/890513267.geojson
+++ b/data/890/513/267/890513267.geojson
@@ -199,8 +199,13 @@
         "gn:id":1797626,
         "gp:id":26198167,
         "hasc:id":"CN.GD.QY",
+        "meso:local_id":"73843900",
         "qs_pg:id":1251601
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055809,
     "wof:geom_alt":[
@@ -217,7 +222,7 @@
         }
     ],
     "wof:id":890513267,
-    "wof:lastmodified":1694493404,
+    "wof:lastmodified":1695886148,
     "wof:name":"Qingyuan",
     "wof:parent_id":85669743,
     "wof:placetype":"county",

--- a/data/890/513/321/890513321.geojson
+++ b/data/890/513/321/890513321.geojson
@@ -202,8 +202,13 @@
         "gn:id":1813170,
         "gp:id":26198210,
         "hasc:id":"CN.HN.ZJ",
+        "meso:local_id":"73843818",
         "qs_pg:id":1287934
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055810,
     "wof:geom_alt":[
@@ -220,7 +225,7 @@
         }
     ],
     "wof:id":890513321,
-    "wof:lastmodified":1694493383,
+    "wof:lastmodified":1695886058,
     "wof:name":"Zhangjiajie",
     "wof:parent_id":85669781,
     "wof:placetype":"county",

--- a/data/890/513/323/890513323.geojson
+++ b/data/890/513/323/890513323.geojson
@@ -199,8 +199,13 @@
         "gn:id":6640435,
         "gp:id":26198215,
         "hasc:id":"CN.AH.CI",
+        "meso:local_id":"73843878",
         "qs_pg:id":1287935
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055811,
     "wof:geom_alt":[
@@ -217,7 +222,7 @@
         }
     ],
     "wof:id":890513323,
-    "wof:lastmodified":1694493381,
+    "wof:lastmodified":1695886054,
     "wof:name":"Chizhou",
     "wof:parent_id":85669739,
     "wof:placetype":"county",

--- a/data/890/513/327/890513327.geojson
+++ b/data/890/513/327/890513327.geojson
@@ -217,8 +217,13 @@
         "gn:id":2038085,
         "gp:id":26198253,
         "hasc:id":"CN.HB.CD",
+        "meso:local_id":"73843831",
         "qs_pg:id":1287946
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055811,
     "wof:geom_alt":[
@@ -235,7 +240,7 @@
         }
     ],
     "wof:id":890513327,
-    "wof:lastmodified":1694493405,
+    "wof:lastmodified":1695886149,
     "wof:name":"Chengde",
     "wof:parent_id":85669797,
     "wof:placetype":"county",

--- a/data/890/513/329/890513329.geojson
+++ b/data/890/513/329/890513329.geojson
@@ -160,9 +160,14 @@
         "gn:id":1814761,
         "gp:id":26198218,
         "hasc:id":"CN.AH.CU",
+        "meso:local_id":"73843907",
         "qs_pg:id":1287947,
         "wd:id":"Q973193"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055811,
     "wof:geom_alt":[
@@ -179,7 +184,7 @@
         }
     ],
     "wof:id":890513329,
-    "wof:lastmodified":1694493382,
+    "wof:lastmodified":1695886057,
     "wof:name":"Chuzhou",
     "wof:parent_id":85669739,
     "wof:placetype":"county",

--- a/data/890/513/331/890513331.geojson
+++ b/data/890/513/331/890513331.geojson
@@ -218,8 +218,13 @@
         "gn:id":1786761,
         "gp:id":26198266,
         "hasc:id":"CN.HU.YC",
+        "meso:local_id":"73843792",
         "qs_pg:id":1287948
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055811,
     "wof:geom_alt":[
@@ -236,7 +241,7 @@
         }
     ],
     "wof:id":890513331,
-    "wof:lastmodified":1694493404,
+    "wof:lastmodified":1695886146,
     "wof:name":"Yichang",
     "wof:parent_id":85669777,
     "wof:placetype":"county",

--- a/data/890/513/333/890513333.geojson
+++ b/data/890/513/333/890513333.geojson
@@ -301,8 +301,13 @@
         "gn:id":1793510,
         "gp:id":26198307,
         "hasc:id":"CN.SX.TY",
+        "meso:local_id":"73843779",
         "qs_pg:id":1287981
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055811,
     "wof:geom_alt":[
@@ -319,7 +324,7 @@
         }
     ],
     "wof:id":890513333,
-    "wof:lastmodified":1694493382,
+    "wof:lastmodified":1695886055,
     "wof:name":"Taiyuan",
     "wof:parent_id":85669773,
     "wof:placetype":"county",

--- a/data/890/513/337/890513337.geojson
+++ b/data/890/513/337/890513337.geojson
@@ -199,8 +199,13 @@
         "gn:id":1805525,
         "gp:id":26198328,
         "hasc:id":"CN.ZJ.JH",
+        "meso:local_id":"73843996",
         "qs_pg:id":1287985
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055812,
     "wof:geom_alt":[
@@ -217,7 +222,7 @@
         }
     ],
     "wof:id":890513337,
-    "wof:lastmodified":1694493404,
+    "wof:lastmodified":1695886146,
     "wof:name":"Jinhua",
     "wof:parent_id":85669835,
     "wof:placetype":"county",

--- a/data/890/513/339/890513339.geojson
+++ b/data/890/513/339/890513339.geojson
@@ -232,8 +232,13 @@
         "gn:id":1785017,
         "gp:id":26198336,
         "hasc:id":"CN.FJ.ZZ",
+        "meso:local_id":"73843910",
         "qs_pg:id":1287992
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055812,
     "wof:geom_alt":[
@@ -250,7 +255,7 @@
         }
     ],
     "wof:id":890513339,
-    "wof:lastmodified":1694493404,
+    "wof:lastmodified":1695886147,
     "wof:name":"Zhangzhou",
     "wof:parent_id":85669735,
     "wof:placetype":"county",

--- a/data/890/513/369/890513369.geojson
+++ b/data/890/513/369/890513369.geojson
@@ -184,8 +184,13 @@
         "gn:id":1805302,
         "gp:id":26198308,
         "hasc:id":"CN.SX.JZ",
+        "meso:local_id":"73843849",
         "qs_pg:id":1310341
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055813,
     "wof:geom_alt":[
@@ -202,7 +207,7 @@
         }
     ],
     "wof:id":890513369,
-    "wof:lastmodified":1694493382,
+    "wof:lastmodified":1695886055,
     "wof:name":"Jinzhong",
     "wof:parent_id":85669773,
     "wof:placetype":"county",

--- a/data/890/513/491/890513491.geojson
+++ b/data/890/513/491/890513491.geojson
@@ -178,8 +178,13 @@
     "wof:concordances":{
         "gn:id":6642609,
         "hasc:id":"CN.SX.SZ",
+        "meso:local_id":"73843854",
         "qs_pg:id":279870
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055818,
     "wof:geom_alt":[
@@ -196,7 +201,7 @@
         }
     ],
     "wof:id":890513491,
-    "wof:lastmodified":1694493404,
+    "wof:lastmodified":1695886148,
     "wof:name":"Shuozhou",
     "wof:parent_id":85669773,
     "wof:placetype":"county",

--- a/data/890/513/745/890513745.geojson
+++ b/data/890/513/745/890513745.geojson
@@ -194,8 +194,10 @@
     "wof:concordances":{
         "gn:id":1802199,
         "gp:id":26198217,
+        "meso:local_id":"73843726",
         "qs_pg:id":335688
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1469055834,
     "wof:geom_alt":[
@@ -212,7 +214,7 @@
         }
     ],
     "wof:id":890513745,
-    "wof:lastmodified":1694493383,
+    "wof:lastmodified":1695886059,
     "wof:name":"Lu'an",
     "wof:parent_id":85669739,
     "wof:placetype":"county",

--- a/data/890/513/773/890513773.geojson
+++ b/data/890/513/773/890513773.geojson
@@ -118,8 +118,10 @@
     "wof:concordances":{
         "gn:id":1803330,
         "gp:id":26198128,
+        "meso:local_id":"73843696",
         "qs_pg:id":354973
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1469055835,
     "wof:geom_alt":[
@@ -136,7 +138,7 @@
         }
     ],
     "wof:id":890513773,
-    "wof:lastmodified":1694493405,
+    "wof:lastmodified":1695886149,
     "wof:name":"Linxia",
     "wof:parent_id":85669711,
     "wof:placetype":"county",

--- a/data/890/513/777/890513777.geojson
+++ b/data/890/513/777/890513777.geojson
@@ -322,8 +322,13 @@
         "gn:id":1804649,
         "gp:id":26198186,
         "hasc:id":"CN.YN.KM",
+        "meso:local_id":"73843844",
         "qs_pg:id":355053
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055835,
     "wof:geom_alt":[
@@ -340,7 +345,7 @@
         }
     ],
     "wof:id":890513777,
-    "wof:lastmodified":1694493381,
+    "wof:lastmodified":1695886054,
     "wof:name":"Kunming",
     "wof:parent_id":85669791,
     "wof:placetype":"county",

--- a/data/890/513/779/890513779.geojson
+++ b/data/890/513/779/890513779.geojson
@@ -94,8 +94,10 @@
     "wof:concordances":{
         "gn:id":2036891,
         "gp:id":26198285,
+        "meso:local_id":"73843755",
         "qs_pg:id":355214
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1469055835,
     "wof:geom_alt":[
@@ -112,7 +114,7 @@
         }
     ],
     "wof:id":890513779,
-    "wof:lastmodified":1694493389,
+    "wof:lastmodified":1695886497,
     "wof:name":"Huhehaote",
     "wof:parent_id":85669847,
     "wof:placetype":"county",

--- a/data/890/513/781/890513781.geojson
+++ b/data/890/513/781/890513781.geojson
@@ -130,8 +130,13 @@
         "gn:id":1279540,
         "gp:id":26198287,
         "hasc:id":"CN.QH.YS",
+        "meso:local_id":"73843920",
         "qs_pg:id":355215
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055835,
     "wof:geom_alt":[
@@ -148,7 +153,7 @@
         }
     ],
     "wof:id":890513781,
-    "wof:lastmodified":1694493383,
+    "wof:lastmodified":1695886057,
     "wof:name":"Yushu",
     "wof:parent_id":85669715,
     "wof:placetype":"county",

--- a/data/890/513/783/890513783.geojson
+++ b/data/890/513/783/890513783.geojson
@@ -226,8 +226,13 @@
         "gn:id":2038299,
         "gp:id":26198282,
         "hasc:id":"CN.LN.BX",
+        "meso:local_id":"73843856",
         "qs_pg:id":355216
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055835,
     "wof:geom_alt":[
@@ -244,7 +249,7 @@
         }
     ],
     "wof:id":890513783,
-    "wof:lastmodified":1694493381,
+    "wof:lastmodified":1695886054,
     "wof:name":"Benxi",
     "wof:parent_id":85669807,
     "wof:placetype":"county",

--- a/data/890/513/785/890513785.geojson
+++ b/data/890/513/785/890513785.geojson
@@ -208,8 +208,13 @@
         "gn:id":1795854,
         "gp:id":26198327,
         "hasc:id":"CN.ZJ.SX",
+        "meso:local_id":"73843943",
         "qs_pg:id":355269
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055835,
     "wof:geom_alt":[
@@ -226,7 +231,7 @@
         }
     ],
     "wof:id":890513785,
-    "wof:lastmodified":1694493381,
+    "wof:lastmodified":1695886055,
     "wof:name":"Shaoxing",
     "wof:parent_id":85669835,
     "wof:placetype":"county",

--- a/data/890/513/787/890513787.geojson
+++ b/data/890/513/787/890513787.geojson
@@ -295,8 +295,13 @@
         "gn:id":1808721,
         "gp:id":26198334,
         "hasc:id":"CN.AH.HF",
+        "meso:local_id":"73843747",
         "qs_pg:id":355324
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055835,
     "wof:geom_alt":[
@@ -313,7 +318,7 @@
         }
     ],
     "wof:id":890513787,
-    "wof:lastmodified":1694493383,
+    "wof:lastmodified":1695886059,
     "wof:name":"Hefei",
     "wof:parent_id":85669739,
     "wof:placetype":"county",

--- a/data/890/513/789/890513789.geojson
+++ b/data/890/513/789/890513789.geojson
@@ -205,8 +205,13 @@
         "gn:id":1816078,
         "gp:id":26198362,
         "hasc:id":"CN.HB.CZ",
+        "meso:local_id":"73843880",
         "qs_pg:id":355395
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055835,
     "wof:geom_alt":[
@@ -223,7 +228,7 @@
         }
     ],
     "wof:id":890513789,
-    "wof:lastmodified":1694493405,
+    "wof:lastmodified":1695886150,
     "wof:name":"Cangzhou",
     "wof:parent_id":85669797,
     "wof:placetype":"county",

--- a/data/890/513/805/890513805.geojson
+++ b/data/890/513/805/890513805.geojson
@@ -164,8 +164,13 @@
     "wof:concordances":{
         "gp:id":26198205,
         "hasc:id":"CN.SC.ZY",
+        "meso:local_id":"73843973",
         "qs_pg:id":358172
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055836,
     "wof:geom_alt":[
@@ -182,7 +187,7 @@
         }
     ],
     "wof:id":890513805,
-    "wof:lastmodified":1694493381,
+    "wof:lastmodified":1695886055,
     "wof:name":"Ziyang",
     "wof:parent_id":85669787,
     "wof:placetype":"county",

--- a/data/890/513/813/890513813.geojson
+++ b/data/890/513/813/890513813.geojson
@@ -416,8 +416,13 @@
     "wof:concordances":{
         "gp:id":26198311,
         "hasc:id":"CN.TJ.TJ",
+        "meso:local_id":"73843777",
         "qs_pg:id":358262
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055836,
     "wof:geom_alt":[
@@ -434,7 +439,7 @@
         }
     ],
     "wof:id":890513813,
-    "wof:lastmodified":1694493382,
+    "wof:lastmodified":1695886057,
     "wof:name":"Tianjin",
     "wof:parent_id":85669817,
     "wof:placetype":"county",

--- a/data/890/513/843/890513843.geojson
+++ b/data/890/513/843/890513843.geojson
@@ -187,8 +187,13 @@
     "wof:concordances":{
         "gn:id":1784128,
         "hasc:id":"CN.HE.ZK",
+        "meso:local_id":"73843753",
         "qs_pg:id":371918
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055838,
     "wof:geom_alt":[
@@ -205,7 +210,7 @@
         }
     ],
     "wof:id":890513843,
-    "wof:lastmodified":1694493404,
+    "wof:lastmodified":1695886148,
     "wof:name":"Zhoukou",
     "wof:parent_id":85669801,
     "wof:placetype":"county",

--- a/data/890/513/907/890513907.geojson
+++ b/data/890/513/907/890513907.geojson
@@ -224,10 +224,15 @@
     "wof:concordances":{
         "gn:id":1796165,
         "hasc:id":"CN.SA.SL",
+        "meso:local_id":"73843763",
         "qs_pg:id":372099,
         "wd:id":"Q515983",
         "wk:page":"Shangluo"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055840,
     "wof:geom_alt":[
@@ -244,7 +249,7 @@
         }
     ],
     "wof:id":890513907,
-    "wof:lastmodified":1694493380,
+    "wof:lastmodified":1695886052,
     "wof:name":"Shangluo",
     "wof:parent_id":85669769,
     "wof:placetype":"county",

--- a/data/890/513/987/890513987.geojson
+++ b/data/890/513/987/890513987.geojson
@@ -178,8 +178,13 @@
     "wof:concordances":{
         "gn:id":1813324,
         "hasc:id":"CN.SC.DZ",
+        "meso:local_id":"73843978",
         "qs_pg:id":372299
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055843,
     "wof:geom_alt":[
@@ -196,7 +201,7 @@
         }
     ],
     "wof:id":890513987,
-    "wof:lastmodified":1694493383,
+    "wof:lastmodified":1695886058,
     "wof:name":"Dazhou",
     "wof:parent_id":85669787,
     "wof:placetype":"county",

--- a/data/890/514/079/890514079.geojson
+++ b/data/890/514/079/890514079.geojson
@@ -199,8 +199,13 @@
         "gn:id":1941243,
         "gp:id":26198106,
         "hasc:id":"CN.HE.PY",
+        "meso:local_id":"73843915",
         "qs_pg:id":1014473
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055847,
     "wof:geom_alt":[
@@ -217,7 +222,7 @@
         }
     ],
     "wof:id":890514079,
-    "wof:lastmodified":1694493401,
+    "wof:lastmodified":1695886138,
     "wof:name":"Puyang",
     "wof:parent_id":85669801,
     "wof:placetype":"county",

--- a/data/890/514/111/890514111.geojson
+++ b/data/890/514/111/890514111.geojson
@@ -172,8 +172,13 @@
     "wof:concordances":{
         "gn:id":1794805,
         "hasc:id":"CN.NX.SZ",
+        "meso:local_id":"73843936",
         "qs_pg:id":1027541
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055848,
     "wof:geom_alt":[
@@ -190,7 +195,7 @@
         }
     ],
     "wof:id":890514111,
-    "wof:lastmodified":1694493402,
+    "wof:lastmodified":1695886140,
     "wof:name":"Shizuishan",
     "wof:parent_id":85669763,
     "wof:placetype":"county",

--- a/data/890/514/127/890514127.geojson
+++ b/data/890/514/127/890514127.geojson
@@ -229,8 +229,13 @@
     "wof:concordances":{
         "gn:id":1797350,
         "hasc:id":"CN.FJ.QZ",
+        "meso:local_id":"73843883",
         "qs_pg:id":1027559
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055848,
     "wof:geom_alt":[
@@ -247,7 +252,7 @@
         }
     ],
     "wof:id":890514127,
-    "wof:lastmodified":1694493402,
+    "wof:lastmodified":1695886140,
     "wof:name":"Quanzhou",
     "wof:parent_id":85669735,
     "wof:placetype":"county",

--- a/data/890/514/155/890514155.geojson
+++ b/data/890/514/155/890514155.geojson
@@ -98,9 +98,14 @@
     "wof:concordances":{
         "gn:id":1801637,
         "hasc:id":"CN.SC.LZ",
+        "meso:local_id":"73843886",
         "qs_pg:id":1027626,
         "wk:page":"Luzhou District"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055849,
     "wof:geom_alt":[
@@ -117,7 +122,7 @@
         }
     ],
     "wof:id":890514155,
-    "wof:lastmodified":1694493402,
+    "wof:lastmodified":1695886142,
     "wof:name":"Luzhou",
     "wof:parent_id":85669787,
     "wof:placetype":"county",

--- a/data/890/514/157/890514157.geojson
+++ b/data/890/514/157/890514157.geojson
@@ -199,8 +199,13 @@
     "wof:concordances":{
         "gn:id":1800626,
         "hasc:id":"CN.SC.MY",
+        "meso:local_id":"73843945",
         "qs_pg:id":1027628
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055849,
     "wof:geom_alt":[
@@ -217,7 +222,7 @@
         }
     ],
     "wof:id":890514157,
-    "wof:lastmodified":1694493400,
+    "wof:lastmodified":1695886136,
     "wof:name":"Mianyang",
     "wof:parent_id":85669787,
     "wof:placetype":"county",

--- a/data/890/514/179/890514179.geojson
+++ b/data/890/514/179/890514179.geojson
@@ -196,8 +196,13 @@
     "wof:concordances":{
         "gn:id":1808200,
         "hasc:id":"CN.GD.HY",
+        "meso:local_id":"73843882",
         "qs_pg:id":1027670
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055850,
     "wof:geom_alt":[
@@ -214,7 +219,7 @@
         }
     ],
     "wof:id":890514179,
-    "wof:lastmodified":1694493403,
+    "wof:lastmodified":1695886145,
     "wof:name":"Heyuan",
     "wof:parent_id":85669743,
     "wof:placetype":"county",

--- a/data/890/514/217/890514217.geojson
+++ b/data/890/514/217/890514217.geojson
@@ -100,8 +100,13 @@
     "wof:concordances":{
         "gn:id":2034711,
         "hasc:id":"CN.JL.SP",
+        "meso:local_id":"73843767",
         "qs_pg:id":1028372
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055853,
     "wof:geom_alt":[
@@ -118,7 +123,7 @@
         }
     ],
     "wof:id":890514217,
-    "wof:lastmodified":1694493401,
+    "wof:lastmodified":1695886138,
     "wof:name":"Siping",
     "wof:parent_id":85669843,
     "wof:placetype":"county",

--- a/data/890/514/231/890514231.geojson
+++ b/data/890/514/231/890514231.geojson
@@ -238,8 +238,13 @@
     "wof:concordances":{
         "gn:id":2038630,
         "hasc:id":"CN.LN.AS",
+        "meso:local_id":"73844026",
         "qs_pg:id":1028417
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055853,
     "wof:geom_alt":[
@@ -256,7 +261,7 @@
         }
     ],
     "wof:id":890514231,
-    "wof:lastmodified":1694493403,
+    "wof:lastmodified":1695886144,
     "wof:name":"Anshan",
     "wof:parent_id":85669807,
     "wof:placetype":"county",

--- a/data/890/514/235/890514235.geojson
+++ b/data/890/514/235/890514235.geojson
@@ -328,8 +328,13 @@
     "wof:concordances":{
         "gn:id":2038176,
         "hasc:id":"CN.JL.CC",
+        "meso:local_id":"73844007",
         "qs_pg:id":1028420
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055853,
     "wof:geom_alt":[
@@ -346,7 +351,7 @@
         }
     ],
     "wof:id":890514235,
-    "wof:lastmodified":1694493378,
+    "wof:lastmodified":1695886047,
     "wof:name":"Changchun",
     "wof:parent_id":85669843,
     "wof:placetype":"county",

--- a/data/890/514/251/890514251.geojson
+++ b/data/890/514/251/890514251.geojson
@@ -136,8 +136,13 @@
     "wof:concordances":{
         "gn:id":1281672,
         "hasc:id":"CN.YN.BS",
+        "meso:local_id":"73843721",
         "qs_pg:id":1030435
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055854,
     "wof:geom_alt":[
@@ -154,7 +159,7 @@
         }
     ],
     "wof:id":890514251,
-    "wof:lastmodified":1694493401,
+    "wof:lastmodified":1695886138,
     "wof:name":"Baoshan",
     "wof:parent_id":85669791,
     "wof:placetype":"county",

--- a/data/890/514/257/890514257.geojson
+++ b/data/890/514/257/890514257.geojson
@@ -190,8 +190,13 @@
     "wof:concordances":{
         "gn:id":1784839,
         "hasc:id":"CN.YN.ZT",
+        "meso:local_id":"73843848",
         "qs_pg:id":1031432
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055854,
     "wof:geom_alt":[
@@ -208,7 +213,7 @@
         }
     ],
     "wof:id":890514257,
-    "wof:lastmodified":1694493378,
+    "wof:lastmodified":1695886048,
     "wof:name":"Zhaotong",
     "wof:parent_id":85669791,
     "wof:placetype":"county",

--- a/data/890/514/289/890514289.geojson
+++ b/data/890/514/289/890514289.geojson
@@ -232,8 +232,13 @@
     "wof:concordances":{
         "gn:id":1791385,
         "hasc:id":"CN.ZJ.WZ",
+        "meso:local_id":"73843901",
         "qs_pg:id":1031493
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055855,
     "wof:geom_alt":[
@@ -250,7 +255,7 @@
         }
     ],
     "wof:id":890514289,
-    "wof:lastmodified":1694493378,
+    "wof:lastmodified":1695886047,
     "wof:name":"Wenzhou",
     "wof:parent_id":85669835,
     "wof:placetype":"county",

--- a/data/890/514/309/890514309.geojson
+++ b/data/890/514/309/890514309.geojson
@@ -191,8 +191,13 @@
     "wof:concordances":{
         "gn:id":1795852,
         "hasc:id":"CN.HN.SY",
+        "meso:local_id":"73843989",
         "qs_pg:id":1031519
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055855,
     "wof:geom_alt":[
@@ -209,7 +214,7 @@
         }
     ],
     "wof:id":890514309,
-    "wof:lastmodified":1694493400,
+    "wof:lastmodified":1695886136,
     "wof:name":"Shaoyang",
     "wof:parent_id":85669781,
     "wof:placetype":"county",

--- a/data/890/514/321/890514321.geojson
+++ b/data/890/514/321/890514321.geojson
@@ -181,8 +181,13 @@
     "wof:concordances":{
         "gn:id":1798997,
         "hasc:id":"CN.SC.PZ",
+        "meso:local_id":"73843836",
         "qs_pg:id":1031537
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055856,
     "wof:geom_alt":[
@@ -199,7 +204,7 @@
         }
     ],
     "wof:id":890514321,
-    "wof:lastmodified":1694493403,
+    "wof:lastmodified":1695886145,
     "wof:name":"Panzhihua",
     "wof:parent_id":85669787,
     "wof:placetype":"county",

--- a/data/890/514/349/890514349.geojson
+++ b/data/890/514/349/890514349.geojson
@@ -178,8 +178,13 @@
     "wof:concordances":{
         "gn:id":1807688,
         "hasc:id":"CN.HN.HH",
+        "meso:local_id":"73843825",
         "qs_pg:id":1031631
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055857,
     "wof:geom_alt":[
@@ -196,7 +201,7 @@
         }
     ],
     "wof:id":890514349,
-    "wof:lastmodified":1694493379,
+    "wof:lastmodified":1695886048,
     "wof:name":"Huaihua",
     "wof:parent_id":85669781,
     "wof:placetype":"county",

--- a/data/890/514/397/890514397.geojson
+++ b/data/890/514/397/890514397.geojson
@@ -205,8 +205,13 @@
     "wof:concordances":{
         "gn:id":2036425,
         "hasc:id":"CN.LN.JZ",
+        "meso:local_id":"73844005",
         "qs_pg:id":1032019
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055859,
     "wof:geom_alt":[
@@ -223,7 +228,7 @@
         }
     ],
     "wof:id":890514397,
-    "wof:lastmodified":1694493400,
+    "wof:lastmodified":1695886137,
     "wof:name":"Jinzhou",
     "wof:parent_id":85669807,
     "wof:placetype":"county",

--- a/data/890/514/399/890514399.geojson
+++ b/data/890/514/399/890514399.geojson
@@ -181,8 +181,13 @@
     "wof:concordances":{
         "gn:id":2036430,
         "hasc:id":"CN.LN.HL",
+        "meso:local_id":"73843960",
         "qs_pg:id":1032020
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055859,
     "wof:geom_alt":[
@@ -199,7 +204,7 @@
         }
     ],
     "wof:id":890514399,
-    "wof:lastmodified":1694493378,
+    "wof:lastmodified":1695886047,
     "wof:name":"Huludao",
     "wof:parent_id":85669807,
     "wof:placetype":"county",

--- a/data/890/514/465/890514465.geojson
+++ b/data/890/514/465/890514465.geojson
@@ -212,8 +212,13 @@
         "gn:id":1798652,
         "gp:id":26198039,
         "hasc:id":"CN.JX.PX",
+        "meso:local_id":"73843958",
         "qs_pg:id":1052152
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055861,
     "wof:geom_alt":[
@@ -230,7 +235,7 @@
         }
     ],
     "wof:id":890514465,
-    "wof:lastmodified":1694493401,
+    "wof:lastmodified":1695886139,
     "wof:name":"Pingxiang",
     "wof:parent_id":85669823,
     "wof:placetype":"county",

--- a/data/890/514/467/890514467.geojson
+++ b/data/890/514/467/890514467.geojson
@@ -187,8 +187,13 @@
     "wof:concordances":{
         "gn:id":1793878,
         "hasc:id":"CN.HU.SZ",
+        "meso:local_id":"73844023",
         "qs_pg:id":1062511
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055862,
     "wof:geom_alt":[
@@ -205,7 +210,7 @@
         }
     ],
     "wof:id":890514467,
-    "wof:lastmodified":1694493379,
+    "wof:lastmodified":1695886049,
     "wof:name":"Suizhou",
     "wof:parent_id":85669777,
     "wof:placetype":"county",

--- a/data/890/514/505/890514505.geojson
+++ b/data/890/514/505/890514505.geojson
@@ -211,8 +211,13 @@
         "gn:id":2036580,
         "gp:id":26198262,
         "hasc:id":"CN.HL.JM",
+        "meso:local_id":"73843718",
         "qs_pg:id":483549
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055863,
     "wof:geom_alt":[
@@ -229,7 +234,7 @@
         }
     ],
     "wof:id":890514505,
-    "wof:lastmodified":1694493400,
+    "wof:lastmodified":1695886136,
     "wof:name":"Jiamusi",
     "wof:parent_id":85669849,
     "wof:placetype":"county",

--- a/data/890/514/507/890514507.geojson
+++ b/data/890/514/507/890514507.geojson
@@ -212,9 +212,14 @@
         "gn:id":1793752,
         "gp:id":26198330,
         "hasc:id":"CN.AH.SZ",
+        "meso:local_id":"73843796",
         "qs_pg:id":483550,
         "wd:id":"Q10935365"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055863,
     "wof:geom_alt":[
@@ -231,7 +236,7 @@
         }
     ],
     "wof:id":890514507,
-    "wof:lastmodified":1694493402,
+    "wof:lastmodified":1695886142,
     "wof:name":"Suzhou",
     "wof:parent_id":85669739,
     "wof:placetype":"county",

--- a/data/890/514/509/890514509.geojson
+++ b/data/890/514/509/890514509.geojson
@@ -199,8 +199,13 @@
         "gn:id":2034654,
         "gp:id":26198258,
         "hasc:id":"CN.HL.SH",
+        "meso:local_id":"73843944",
         "qs_pg:id":483551
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055863,
     "wof:geom_alt":[
@@ -217,7 +222,7 @@
         }
     ],
     "wof:id":890514509,
-    "wof:lastmodified":1694493402,
+    "wof:lastmodified":1695886142,
     "wof:name":"Suihua",
     "wof:parent_id":85669849,
     "wof:placetype":"county",

--- a/data/890/514/515/890514515.geojson
+++ b/data/890/514/515/890514515.geojson
@@ -190,8 +190,10 @@
     "wof:concordances":{
         "gn:id":1811618,
         "gp:id":26198040,
+        "meso:local_id":"73843993",
         "qs_pg:id":1337496
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1469055864,
     "wof:geom_alt":[
@@ -208,7 +210,7 @@
         }
     ],
     "wof:id":890514515,
-    "wof:lastmodified":1694493379,
+    "wof:lastmodified":1695886050,
     "wof:name":"Ezhou",
     "wof:parent_id":85669777,
     "wof:placetype":"county",

--- a/data/890/514/517/890514517.geojson
+++ b/data/890/514/517/890514517.geojson
@@ -208,8 +208,13 @@
         "gn:id":1792619,
         "gp:id":26198331,
         "hasc:id":"CN.AH.TL",
+        "meso:local_id":"73844002",
         "qs_pg:id":483555
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055864,
     "wof:geom_alt":[
@@ -226,7 +231,7 @@
         }
     ],
     "wof:id":890514517,
-    "wof:lastmodified":1694493401,
+    "wof:lastmodified":1695886139,
     "wof:name":"Tongling",
     "wof:parent_id":85669739,
     "wof:placetype":"county",

--- a/data/890/514/543/890514543.geojson
+++ b/data/890/514/543/890514543.geojson
@@ -92,8 +92,13 @@
     "wof:concordances":{
         "gp:id":26198315,
         "hasc:id":"CN.XJ.TL",
+        "meso:local_id":"73843750",
         "qs_pg:id":423119
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055865,
     "wof:geom_alt":[
@@ -110,7 +115,7 @@
         }
     ],
     "wof:id":890514543,
-    "wof:lastmodified":1694493393,
+    "wof:lastmodified":1695886504,
     "wof:name":"Tulufan",
     "wof:parent_id":85669753,
     "wof:placetype":"county",

--- a/data/890/514/545/890514545.geojson
+++ b/data/890/514/545/890514545.geojson
@@ -92,8 +92,13 @@
     "wof:concordances":{
         "gp:id":26198318,
         "hasc:id":"CN.XZ.CD",
+        "meso:local_id":"73843847",
         "qs_pg:id":423120
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055865,
     "wof:geom_alt":[
@@ -110,7 +115,7 @@
         }
     ],
     "wof:id":890514545,
-    "wof:lastmodified":1694493388,
+    "wof:lastmodified":1695886493,
     "wof:name":"Changdu",
     "wof:parent_id":85669747,
     "wof:placetype":"county",

--- a/data/890/514/553/890514553.geojson
+++ b/data/890/514/553/890514553.geojson
@@ -149,8 +149,13 @@
         "gn:id":1786745,
         "gp:id":26198155,
         "hasc:id":"CN.JX.YC",
+        "meso:local_id":"73843793",
         "qs_pg:id":31776
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055865,
     "wof:geom_alt":[
@@ -167,7 +172,7 @@
         }
     ],
     "wof:id":890514553,
-    "wof:lastmodified":1694493403,
+    "wof:lastmodified":1695886144,
     "wof:name":"Yichun",
     "wof:parent_id":85669823,
     "wof:placetype":"county",

--- a/data/890/514/555/890514555.geojson
+++ b/data/890/514/555/890514555.geojson
@@ -181,8 +181,13 @@
         "gn:id":1803589,
         "gp:id":26198322,
         "hasc:id":"CN.YN.LC",
+        "meso:local_id":"73843699",
         "qs_pg:id":31874
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055865,
     "wof:geom_alt":[
@@ -199,7 +204,7 @@
         }
     ],
     "wof:id":890514555,
-    "wof:lastmodified":1694493379,
+    "wof:lastmodified":1695886049,
     "wof:name":"Lincang",
     "wof:parent_id":85669791,
     "wof:placetype":"county",

--- a/data/890/514/591/890514591.geojson
+++ b/data/890/514/591/890514591.geojson
@@ -137,8 +137,13 @@
     "wof:concordances":{
         "gp:id":26198248,
         "hasc:id":"CN.GX.YL",
+        "meso:local_id":"73843919",
         "qs_pg:id":358199
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055867,
     "wof:geom_alt":[
@@ -155,7 +160,7 @@
         }
     ],
     "wof:id":890514591,
-    "wof:lastmodified":1694493403,
+    "wof:lastmodified":1695886143,
     "wof:name":"Yulin",
     "wof:parent_id":85669717,
     "wof:placetype":"county",

--- a/data/890/514/597/890514597.geojson
+++ b/data/890/514/597/890514597.geojson
@@ -199,8 +199,13 @@
         "gn:id":2038066,
         "gp:id":26198068,
         "hasc:id":"CN.NM.CF",
+        "meso:local_id":"73843975",
         "qs_pg:id":354943
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055868,
     "wof:geom_alt":[
@@ -217,7 +222,7 @@
         }
     ],
     "wof:id":890514597,
-    "wof:lastmodified":1694493402,
+    "wof:lastmodified":1695886142,
     "wof:name":"Chifeng",
     "wof:parent_id":85669847,
     "wof:placetype":"county",

--- a/data/890/514/599/890514599.geojson
+++ b/data/890/514/599/890514599.geojson
@@ -205,8 +205,13 @@
         "gn:id":1805679,
         "gp:id":26198148,
         "hasc:id":"CN.JX.JD",
+        "meso:local_id":"73843852",
         "qs_pg:id":355008
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055868,
     "wof:geom_alt":[
@@ -223,7 +228,7 @@
         }
     ],
     "wof:id":890514599,
-    "wof:lastmodified":1694493402,
+    "wof:lastmodified":1695886142,
     "wof:name":"Jingdezhen",
     "wof:parent_id":85669823,
     "wof:placetype":"county",

--- a/data/890/514/607/890514607.geojson
+++ b/data/890/514/607/890514607.geojson
@@ -191,8 +191,13 @@
         "gn:id":1806430,
         "gp:id":26198153,
         "hasc:id":"CN.JX.JA",
+        "meso:local_id":"73843748",
         "qs_pg:id":428047
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055868,
     "wof:geom_alt":[
@@ -209,7 +214,7 @@
         }
     ],
     "wof:id":890514607,
-    "wof:lastmodified":1694493379,
+    "wof:lastmodified":1695886050,
     "wof:name":"Ji'an",
     "wof:parent_id":85669823,
     "wof:placetype":"county",

--- a/data/890/514/609/890514609.geojson
+++ b/data/890/514/609/890514609.geojson
@@ -229,8 +229,13 @@
         "gn:id":1806297,
         "gp:id":26198350,
         "hasc:id":"CN.GD.JM",
+        "meso:local_id":"73843877",
         "qs_pg:id":428082
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055868,
     "wof:geom_alt":[
@@ -247,7 +252,7 @@
         }
     ],
     "wof:id":890514609,
-    "wof:lastmodified":1694493403,
+    "wof:lastmodified":1695886145,
     "wof:name":"Jiangmen",
     "wof:parent_id":85669743,
     "wof:placetype":"county",

--- a/data/890/514/633/890514633.geojson
+++ b/data/890/514/633/890514633.geojson
@@ -193,8 +193,13 @@
         "gn:id":1797262,
         "gp:id":26198146,
         "hasc:id":"CN.ZJ.QZ",
+        "meso:local_id":"73843964",
         "qs_pg:id":488195
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055869,
     "wof:geom_alt":[
@@ -211,7 +216,7 @@
         }
     ],
     "wof:id":890514633,
-    "wof:lastmodified":1694493401,
+    "wof:lastmodified":1695886139,
     "wof:name":"Quzhou",
     "wof:parent_id":85669835,
     "wof:placetype":"county",

--- a/data/890/514/635/890514635.geojson
+++ b/data/890/514/635/890514635.geojson
@@ -205,8 +205,13 @@
         "gn:id":1805952,
         "gp:id":26198142,
         "hasc:id":"CN.ZJ.JX",
+        "meso:local_id":"73843765",
         "qs_pg:id":488197
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055869,
     "wof:geom_alt":[
@@ -223,7 +228,7 @@
         }
     ],
     "wof:id":890514635,
-    "wof:lastmodified":1694493379,
+    "wof:lastmodified":1695886048,
     "wof:name":"Jiaxing",
     "wof:parent_id":85669835,
     "wof:placetype":"county",

--- a/data/890/514/637/890514637.geojson
+++ b/data/890/514/637/890514637.geojson
@@ -193,8 +193,13 @@
         "gn:id":1790395,
         "gp:id":26198157,
         "hasc:id":"CN.HU.XN",
+        "meso:local_id":"73843757",
         "qs_pg:id":488207
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055869,
     "wof:geom_alt":[
@@ -211,7 +216,7 @@
         }
     ],
     "wof:id":890514637,
-    "wof:lastmodified":1694493379,
+    "wof:lastmodified":1695886050,
     "wof:name":"Xianning",
     "wof:parent_id":85669777,
     "wof:placetype":"county",

--- a/data/890/514/641/890514641.geojson
+++ b/data/890/514/641/890514641.geojson
@@ -200,8 +200,13 @@
         "gn:id":6643374,
         "gp:id":26198202,
         "hasc:id":"CN.SC.SN",
+        "meso:local_id":"73843984",
         "qs_pg:id":488221
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055869,
     "wof:geom_alt":[
@@ -218,7 +223,7 @@
         }
     ],
     "wof:id":890514641,
-    "wof:lastmodified":1694493403,
+    "wof:lastmodified":1695886144,
     "wof:name":"Suining",
     "wof:parent_id":85669787,
     "wof:placetype":"county",

--- a/data/890/514/643/890514643.geojson
+++ b/data/890/514/643/890514643.geojson
@@ -220,8 +220,13 @@
         "gn:id":2036112,
         "gp:id":26198227,
         "hasc:id":"CN.LN.LY",
+        "meso:local_id":"73843977",
         "qs_pg:id":488222
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055869,
     "wof:geom_alt":[
@@ -238,7 +243,7 @@
         }
     ],
     "wof:id":890514643,
-    "wof:lastmodified":1694493401,
+    "wof:lastmodified":1695886138,
     "wof:name":"Liaoyang",
     "wof:parent_id":85669807,
     "wof:placetype":"county",

--- a/data/890/514/701/890514701.geojson
+++ b/data/890/514/701/890514701.geojson
@@ -241,8 +241,13 @@
         "gn:id":1803666,
         "gp:id":26198191,
         "hasc:id":"CN.YN.LJ",
+        "meso:local_id":"73843703",
         "qs_pg:id":498842
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055872,
     "wof:geom_alt":[
@@ -259,7 +264,7 @@
         }
     ],
     "wof:id":890514701,
-    "wof:lastmodified":1694493400,
+    "wof:lastmodified":1695886137,
     "wof:name":"Lijiang",
     "wof:parent_id":85669791,
     "wof:placetype":"county",

--- a/data/890/514/703/890514703.geojson
+++ b/data/890/514/703/890514703.geojson
@@ -104,8 +104,10 @@
     "wof:concordances":{
         "gn:id":1810269,
         "gp:id":26198324,
+        "meso:local_id":"73843926",
         "qs_pg:id":498874
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1469055872,
     "wof:geom_alt":[
@@ -122,7 +124,7 @@
         }
     ],
     "wof:id":890514703,
-    "wof:lastmodified":1694493389,
+    "wof:lastmodified":1695886495,
     "wof:name":"Ganzi",
     "wof:parent_id":85669787,
     "wof:placetype":"county",

--- a/data/890/514/709/890514709.geojson
+++ b/data/890/514/709/890514709.geojson
@@ -214,8 +214,13 @@
         "gn:id":2037337,
         "gp:id":26198072,
         "hasc:id":"CN.LN.FX",
+        "meso:local_id":"73844010",
         "qs_pg:id":503870
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055873,
     "wof:geom_alt":[
@@ -232,7 +237,7 @@
         }
     ],
     "wof:id":890514709,
-    "wof:lastmodified":1694493401,
+    "wof:lastmodified":1695886137,
     "wof:name":"Fuxin",
     "wof:parent_id":85669807,
     "wof:placetype":"county",

--- a/data/890/514/725/890514725.geojson
+++ b/data/890/514/725/890514725.geojson
@@ -250,8 +250,13 @@
         "gn:id":2037885,
         "gp:id":26198226,
         "hasc:id":"CN.LN.DD",
+        "meso:local_id":"73843701",
         "qs_pg:id":890387
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055874,
     "wof:geom_alt":[
@@ -268,7 +273,7 @@
         }
     ],
     "wof:id":890514725,
-    "wof:lastmodified":1694493401,
+    "wof:lastmodified":1695886140,
     "wof:name":"Dandong",
     "wof:parent_id":85669807,
     "wof:placetype":"county",

--- a/data/890/514/727/890514727.geojson
+++ b/data/890/514/727/890514727.geojson
@@ -214,8 +214,13 @@
         "gn:id":1784852,
         "gp:id":26198243,
         "hasc:id":"CN.GD.ZQ",
+        "meso:local_id":"73843947",
         "qs_pg:id":890389
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055874,
     "wof:geom_alt":[
@@ -232,7 +237,7 @@
         }
     ],
     "wof:id":890514727,
-    "wof:lastmodified":1694493404,
+    "wof:lastmodified":1695886146,
     "wof:name":"Zhaoqing",
     "wof:parent_id":85669743,
     "wof:placetype":"county",

--- a/data/890/514/731/890514731.geojson
+++ b/data/890/514/731/890514731.geojson
@@ -190,8 +190,13 @@
         "gn:id":1805610,
         "gp:id":26198268,
         "hasc:id":"CN.HU.JM",
+        "meso:local_id":"73843954",
         "qs_pg:id":890390
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055874,
     "wof:geom_alt":[
@@ -208,7 +213,7 @@
         }
     ],
     "wof:id":890514731,
-    "wof:lastmodified":1694493401,
+    "wof:lastmodified":1695886137,
     "wof:name":"Jingmen",
     "wof:parent_id":85669777,
     "wof:placetype":"county",

--- a/data/890/514/733/890514733.geojson
+++ b/data/890/514/733/890514733.geojson
@@ -116,9 +116,14 @@
         "gn:id":1790902,
         "gp:id":26198275,
         "hasc:id":"CN.JS.WX",
+        "meso:local_id":"73843841",
         "qs_pg:id":890391,
         "wd:id":"Q10878142"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055874,
     "wof:geom_alt":[
@@ -135,7 +140,7 @@
         }
     ],
     "wof:id":890514733,
-    "wof:lastmodified":1694493393,
+    "wof:lastmodified":1695886504,
     "wof:name":"Wuxi",
     "wof:parent_id":85669827,
     "wof:placetype":"county",

--- a/data/890/514/735/890514735.geojson
+++ b/data/890/514/735/890514735.geojson
@@ -235,8 +235,13 @@
         "gn:id":1815454,
         "gp:id":26198276,
         "hasc:id":"CN.JS.CZ",
+        "meso:local_id":"73843805",
         "qs_pg:id":890392
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055875,
     "wof:geom_alt":[
@@ -253,7 +258,7 @@
         }
     ],
     "wof:id":890514735,
-    "wof:lastmodified":1694493379,
+    "wof:lastmodified":1695886049,
     "wof:name":"Changzhou",
     "wof:parent_id":85669827,
     "wof:placetype":"county",

--- a/data/890/514/737/890514737.geojson
+++ b/data/890/514/737/890514737.geojson
@@ -406,8 +406,13 @@
         "gn:id":1795563,
         "gp:id":26198346,
         "hasc:id":"CN.GD.SZ",
+        "meso:local_id":"73843899",
         "qs_pg:id":891428
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055875,
     "wof:geom_alt":[
@@ -424,7 +429,7 @@
         }
     ],
     "wof:id":890514737,
-    "wof:lastmodified":1694493378,
+    "wof:lastmodified":1695886046,
     "wof:name":"Shenzhen",
     "wof:parent_id":85669743,
     "wof:placetype":"county",

--- a/data/890/514/741/890514741.geojson
+++ b/data/890/514/741/890514741.geojson
@@ -193,8 +193,13 @@
         "gn:id":2034437,
         "gp:id":26198076,
         "hasc:id":"CN.LN.TL",
+        "meso:local_id":"73843999",
         "qs_pg:id":894110
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055875,
     "wof:geom_alt":[
@@ -211,7 +216,7 @@
         }
     ],
     "wof:id":890514741,
-    "wof:lastmodified":1694493402,
+    "wof:lastmodified":1695886141,
     "wof:name":"Tieling",
     "wof:parent_id":85669807,
     "wof:placetype":"county",

--- a/data/890/514/743/890514743.geojson
+++ b/data/890/514/743/890514743.geojson
@@ -190,8 +190,13 @@
         "gn:id":2036421,
         "gp:id":26198078,
         "hasc:id":"CN.NM.TL",
+        "meso:local_id":"73843983",
         "qs_pg:id":894111
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055875,
     "wof:geom_alt":[
@@ -208,7 +213,7 @@
         }
     ],
     "wof:id":890514743,
-    "wof:lastmodified":1694493403,
+    "wof:lastmodified":1695886145,
     "wof:name":"Tongliao",
     "wof:parent_id":85669847,
     "wof:placetype":"county",

--- a/data/890/514/745/890514745.geojson
+++ b/data/890/514/745/890514745.geojson
@@ -193,8 +193,13 @@
         "gn:id":1785736,
         "gp:id":26198109,
         "hasc:id":"CN.SX.YC",
+        "meso:local_id":"73843979",
         "qs_pg:id":894112
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055875,
     "wof:geom_alt":[
@@ -211,7 +216,7 @@
         }
     ],
     "wof:id":890514745,
-    "wof:lastmodified":1694493380,
+    "wof:lastmodified":1695886051,
     "wof:name":"Yuncheng",
     "wof:parent_id":85669773,
     "wof:placetype":"county",

--- a/data/890/514/749/890514749.geojson
+++ b/data/890/514/749/890514749.geojson
@@ -193,8 +193,13 @@
         "gn:id":1805739,
         "gp:id":26198110,
         "hasc:id":"CN.SX.JC",
+        "meso:local_id":"73843850",
         "qs_pg:id":894113
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055875,
     "wof:geom_alt":[
@@ -211,7 +216,7 @@
         }
     ],
     "wof:id":890514749,
-    "wof:lastmodified":1694493402,
+    "wof:lastmodified":1695886140,
     "wof:name":"Jincheng",
     "wof:parent_id":85669773,
     "wof:placetype":"county",

--- a/data/890/514/753/890514753.geojson
+++ b/data/890/514/753/890514753.geojson
@@ -217,8 +217,13 @@
         "gn:id":1784987,
         "gp:id":26198171,
         "hasc:id":"CN.GD.ZJ",
+        "meso:local_id":"73843906",
         "qs_pg:id":896543
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055875,
     "wof:geom_alt":[
@@ -235,7 +240,7 @@
         }
     ],
     "wof:id":890514753,
-    "wof:lastmodified":1694493401,
+    "wof:lastmodified":1695886137,
     "wof:name":"Zhanjiang",
     "wof:parent_id":85669743,
     "wof:placetype":"county",

--- a/data/890/514/755/890514755.geojson
+++ b/data/890/514/755/890514755.geojson
@@ -220,8 +220,13 @@
         "gn:id":1791680,
         "gp:id":26198301,
         "hasc:id":"CN.SD.WF",
+        "meso:local_id":"73843911",
         "qs_pg:id":896548
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055875,
     "wof:geom_alt":[
@@ -238,7 +243,7 @@
         }
     ],
     "wof:id":890514755,
-    "wof:lastmodified":1694493400,
+    "wof:lastmodified":1695886137,
     "wof:name":"Weifang",
     "wof:parent_id":85669813,
     "wof:placetype":"county",

--- a/data/890/514/757/890514757.geojson
+++ b/data/890/514/757/890514757.geojson
@@ -202,8 +202,13 @@
         "gn:id":1797131,
         "gp:id":26198302,
         "hasc:id":"CN.SD.RZ",
+        "meso:local_id":"73843843",
         "qs_pg:id":896549
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055875,
     "wof:geom_alt":[
@@ -220,7 +225,7 @@
         }
     ],
     "wof:id":890514757,
-    "wof:lastmodified":1694493403,
+    "wof:lastmodified":1695886143,
     "wof:name":"Rizhao",
     "wof:parent_id":85669813,
     "wof:placetype":"county",

--- a/data/890/514/759/890514759.geojson
+++ b/data/890/514/759/890514759.geojson
@@ -203,8 +203,13 @@
     "wof:concordances":{
         "gp:id":26198214,
         "hasc:id":"CN.HN.ZZ",
+        "meso:local_id":"73843864",
         "qs_pg:id":896597
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055876,
     "wof:geom_alt":[
@@ -221,7 +226,7 @@
         }
     ],
     "wof:id":890514759,
-    "wof:lastmodified":1694493403,
+    "wof:lastmodified":1695886144,
     "wof:name":"Zhuzhou",
     "wof:parent_id":85669781,
     "wof:placetype":"county",

--- a/data/890/514/771/890514771.geojson
+++ b/data/890/514/771/890514771.geojson
@@ -211,8 +211,13 @@
         "gn:id":1791671,
         "gp:id":26198081,
         "hasc:id":"CN.SD.WH",
+        "meso:local_id":"73843780",
         "qs_pg:id":898921
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055876,
     "wof:geom_alt":[
@@ -229,7 +234,7 @@
         }
     ],
     "wof:id":890514771,
-    "wof:lastmodified":1694493402,
+    "wof:lastmodified":1695886141,
     "wof:name":"Weihai",
     "wof:parent_id":85669813,
     "wof:placetype":"county",

--- a/data/890/514/773/890514773.geojson
+++ b/data/890/514/773/890514773.geojson
@@ -152,9 +152,14 @@
         "gn:id":1812099,
         "gp:id":26198082,
         "hasc:id":"CN.SD.DY",
+        "meso:local_id":"73843693",
         "qs_pg:id":898922,
         "wd:id":"Q979215"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055876,
     "wof:geom_alt":[
@@ -171,7 +176,7 @@
         }
     ],
     "wof:id":890514773,
-    "wof:lastmodified":1694493380,
+    "wof:lastmodified":1695886051,
     "wof:name":"Dongying",
     "wof:parent_id":85669813,
     "wof:placetype":"county",

--- a/data/890/514/775/890514775.geojson
+++ b/data/890/514/775/890514775.geojson
@@ -331,8 +331,13 @@
         "gn:id":1797926,
         "gp:id":26198083,
         "hasc:id":"CN.SD.QD",
+        "meso:local_id":"73844025",
         "qs_pg:id":898923
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055876,
     "wof:geom_alt":[
@@ -349,7 +354,7 @@
         }
     ],
     "wof:id":890514775,
-    "wof:lastmodified":1694493403,
+    "wof:lastmodified":1695886146,
     "wof:name":"Qingdao",
     "wof:parent_id":85669813,
     "wof:placetype":"county",

--- a/data/890/514/777/890514777.geojson
+++ b/data/890/514/777/890514777.geojson
@@ -202,8 +202,13 @@
         "gn:id":1803847,
         "gp:id":26198091,
         "hasc:id":"CN.JS.LY",
+        "meso:local_id":"73843980",
         "qs_pg:id":898924
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055876,
     "wof:geom_alt":[
@@ -220,7 +225,7 @@
         }
     ],
     "wof:id":890514777,
-    "wof:lastmodified":1694493402,
+    "wof:lastmodified":1695886141,
     "wof:name":"Lianyungang",
     "wof:parent_id":85669827,
     "wof:placetype":"county",

--- a/data/890/514/791/890514791.geojson
+++ b/data/890/514/791/890514791.geojson
@@ -196,8 +196,13 @@
         "gn:id":1807500,
         "gp:id":26198267,
         "hasc:id":"CN.HU.HG",
+        "meso:local_id":"73844034",
         "qs_pg:id":906389
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055877,
     "wof:geom_alt":[
@@ -214,7 +219,7 @@
         }
     ],
     "wof:id":890514791,
-    "wof:lastmodified":1694493378,
+    "wof:lastmodified":1695886046,
     "wof:name":"Huanggang",
     "wof:parent_id":85669777,
     "wof:placetype":"county",

--- a/data/890/514/815/890514815.geojson
+++ b/data/890/514/815/890514815.geojson
@@ -611,8 +611,13 @@
     "wof:concordances":{
         "gp:id":26198093,
         "hasc:id":"CN.SH.SH",
+        "meso:local_id":"73843689",
         "qs_pg:id":959230
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055878,
     "wof:geom_alt":[
@@ -629,7 +634,7 @@
         }
     ],
     "wof:id":890514815,
-    "wof:lastmodified":1694493379,
+    "wof:lastmodified":1695886050,
     "wof:name":"Shanghai",
     "wof:parent_id":85669831,
     "wof:placetype":"county",

--- a/data/890/514/843/890514843.geojson
+++ b/data/890/514/843/890514843.geojson
@@ -193,8 +193,13 @@
         "gn:id":1783872,
         "gp:id":26198101,
         "hasc:id":"CN.HE.ZM",
+        "meso:local_id":"73844029",
         "qs_pg:id":985555
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055879,
     "wof:geom_alt":[
@@ -211,7 +216,7 @@
         }
     ],
     "wof:id":890514843,
-    "wof:lastmodified":1694493379,
+    "wof:lastmodified":1695886048,
     "wof:name":"Zhumadian",
     "wof:parent_id":85669801,
     "wof:placetype":"county",

--- a/data/890/514/845/890514845.geojson
+++ b/data/890/514/845/890514845.geojson
@@ -198,8 +198,13 @@
         "gn:id":1796132,
         "gp:id":26198103,
         "hasc:id":"CN.HE.SQ",
+        "meso:local_id":"73843762",
         "qs_pg:id":985556
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055879,
     "wof:geom_alt":[
@@ -216,7 +221,7 @@
         }
     ],
     "wof:id":890514845,
-    "wof:lastmodified":1694493401,
+    "wof:lastmodified":1695886138,
     "wof:name":"Shangqiu",
     "wof:parent_id":85669801,
     "wof:placetype":"county",

--- a/data/890/514/875/890514875.geojson
+++ b/data/890/514/875/890514875.geojson
@@ -199,8 +199,13 @@
     "wof:concordances":{
         "gn:id":2036985,
         "hasc:id":"CN.HL.HG",
+        "meso:local_id":"73844032",
         "qs_pg:id":846712
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055880,
     "wof:geom_alt":[
@@ -217,7 +222,7 @@
         }
     ],
     "wof:id":890514875,
-    "wof:lastmodified":1694493401,
+    "wof:lastmodified":1695886139,
     "wof:name":"Hegang",
     "wof:parent_id":85669849,
     "wof:placetype":"county",

--- a/data/890/514/877/890514877.geojson
+++ b/data/890/514/877/890514877.geojson
@@ -193,8 +193,13 @@
         "gn:id":1791248,
         "gp:id":26198045,
         "hasc:id":"CN.NM.WH",
+        "meso:local_id":"73843705",
         "qs_pg:id":1001584
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055880,
     "wof:geom_alt":[
@@ -211,7 +216,7 @@
         }
     ],
     "wof:id":890514877,
-    "wof:lastmodified":1694493403,
+    "wof:lastmodified":1695886144,
     "wof:name":"Wuhai",
     "wof:parent_id":85669847,
     "wof:placetype":"county",

--- a/data/890/514/939/890514939.geojson
+++ b/data/890/514/939/890514939.geojson
@@ -178,8 +178,13 @@
         "gn:id":1786576,
         "gp:id":26198149,
         "hasc:id":"CN.JX.YT",
+        "meso:local_id":"73844033",
         "qs_pg:id":1013992
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055883,
     "wof:geom_alt":[
@@ -196,7 +201,7 @@
         }
     ],
     "wof:id":890514939,
-    "wof:lastmodified":1694493378,
+    "wof:lastmodified":1695886047,
     "wof:name":"Yingtan",
     "wof:parent_id":85669823,
     "wof:placetype":"county",

--- a/data/890/514/995/890514995.geojson
+++ b/data/890/514/995/890514995.geojson
@@ -79,8 +79,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":26198323,
+        "meso:local_id":"73843851",
         "qs_pg:id":889899
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1469055885,
     "wof:geom_alt":[
@@ -97,7 +99,7 @@
         }
     ],
     "wof:id":890514995,
-    "wof:lastmodified":1694493392,
+    "wof:lastmodified":1695886502,
     "wof:name":"Pu'er",
     "wof:parent_id":85669791,
     "wof:placetype":"county",

--- a/data/890/515/001/890515001.geojson
+++ b/data/890/515/001/890515001.geojson
@@ -179,8 +179,13 @@
     "wof:concordances":{
         "gp:id":26198161,
         "hasc:id":"CN.HN.YZ",
+        "meso:local_id":"73843873",
         "qs_pg:id":890439
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055885,
     "wof:geom_alt":[
@@ -197,7 +202,7 @@
         }
     ],
     "wof:id":890515001,
-    "wof:lastmodified":1694493407,
+    "wof:lastmodified":1695886154,
     "wof:name":"Yongzhou",
     "wof:parent_id":85669781,
     "wof:placetype":"county",

--- a/data/890/515/003/890515003.geojson
+++ b/data/890/515/003/890515003.geojson
@@ -161,8 +161,13 @@
     "wof:concordances":{
         "gp:id":26198198,
         "hasc:id":"CN.SC.MS",
+        "meso:local_id":"73843935",
         "qs_pg:id":890445
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055886,
     "wof:geom_alt":[
@@ -179,7 +184,7 @@
         }
     ],
     "wof:id":890515003,
-    "wof:lastmodified":1694493386,
+    "wof:lastmodified":1695886065,
     "wof:name":"Meishan",
     "wof:parent_id":85669787,
     "wof:placetype":"county",

--- a/data/890/515/063/890515063.geojson
+++ b/data/890/515/063/890515063.geojson
@@ -187,8 +187,13 @@
     "wof:concordances":{
         "gn:id":1788080,
         "hasc:id":"CN.AH.XC",
+        "meso:local_id":"73843795",
         "qs_pg:id":903652
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055888,
     "wof:geom_alt":[
@@ -205,7 +210,7 @@
         }
     ],
     "wof:id":890515063,
-    "wof:lastmodified":1694493385,
+    "wof:lastmodified":1695886062,
     "wof:name":"Xuancheng",
     "wof:parent_id":85669739,
     "wof:placetype":"county",

--- a/data/890/515/095/890515095.geojson
+++ b/data/890/515/095/890515095.geojson
@@ -209,8 +209,13 @@
     "wof:concordances":{
         "gp:id":26198111,
         "hasc:id":"CN.SD.ZB",
+        "meso:local_id":"73843895",
         "qs_pg:id":1061972
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055890,
     "wof:geom_alt":[
@@ -227,7 +232,7 @@
         }
     ],
     "wof:id":890515095,
-    "wof:lastmodified":1694493408,
+    "wof:lastmodified":1695886157,
     "wof:name":"Zibo",
     "wof:parent_id":85669813,
     "wof:placetype":"county",

--- a/data/890/515/097/890515097.geojson
+++ b/data/890/515/097/890515097.geojson
@@ -137,8 +137,13 @@
     "wof:concordances":{
         "gp:id":26198114,
         "hasc:id":"CN.SA.YL",
+        "meso:local_id":"73843869",
         "qs_pg:id":1061981
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055890,
     "wof:geom_alt":[
@@ -155,7 +160,7 @@
         }
     ],
     "wof:id":890515097,
-    "wof:lastmodified":1694493407,
+    "wof:lastmodified":1695886154,
     "wof:name":"Yulin",
     "wof:parent_id":85669769,
     "wof:placetype":"county",

--- a/data/890/515/099/890515099.geojson
+++ b/data/890/515/099/890515099.geojson
@@ -182,8 +182,13 @@
     "wof:concordances":{
         "gp:id":26198117,
         "hasc:id":"CN.SA.HZ",
+        "meso:local_id":"73843874",
         "qs_pg:id":1061983
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055890,
     "wof:geom_alt":[
@@ -200,7 +205,7 @@
         }
     ],
     "wof:id":890515099,
-    "wof:lastmodified":1694493406,
+    "wof:lastmodified":1695886153,
     "wof:name":"Hanzhong",
     "wof:parent_id":85669769,
     "wof:placetype":"county",

--- a/data/890/515/101/890515101.geojson
+++ b/data/890/515/101/890515101.geojson
@@ -191,8 +191,13 @@
     "wof:concordances":{
         "gp:id":26198116,
         "hasc:id":"CN.SA.AK",
+        "meso:local_id":"73843786",
         "qs_pg:id":1061985
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055890,
     "wof:geom_alt":[
@@ -209,7 +214,7 @@
         }
     ],
     "wof:id":890515101,
-    "wof:lastmodified":1694493408,
+    "wof:lastmodified":1695886156,
     "wof:name":"Ankang",
     "wof:parent_id":85669769,
     "wof:placetype":"county",

--- a/data/890/515/127/890515127.geojson
+++ b/data/890/515/127/890515127.geojson
@@ -215,8 +215,13 @@
     "wof:concordances":{
         "gp:id":26198249,
         "hasc:id":"CN.GX.LZ",
+        "meso:local_id":"73843863",
         "qs_pg:id":1080140
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055891,
     "wof:geom_alt":[
@@ -233,7 +238,7 @@
         }
     ],
     "wof:id":890515127,
-    "wof:lastmodified":1694493407,
+    "wof:lastmodified":1695886155,
     "wof:name":"Liuzhou",
     "wof:parent_id":85669717,
     "wof:placetype":"county",

--- a/data/890/515/153/890515153.geojson
+++ b/data/890/515/153/890515153.geojson
@@ -214,8 +214,13 @@
         "gn:id":1787743,
         "gp:id":26198092,
         "hasc:id":"CN.JS.YC",
+        "meso:local_id":"73843933",
         "qs_pg:id":1086170
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055892,
     "wof:geom_alt":[
@@ -232,7 +237,7 @@
         }
     ],
     "wof:id":890515153,
-    "wof:lastmodified":1694493407,
+    "wof:lastmodified":1695886155,
     "wof:name":"Yancheng",
     "wof:parent_id":85669827,
     "wof:placetype":"county",

--- a/data/890/515/155/890515155.geojson
+++ b/data/890/515/155/890515155.geojson
@@ -215,8 +215,13 @@
         "gn:id":1799719,
         "gp:id":26198095,
         "hasc:id":"CN.JS.NT",
+        "meso:local_id":"73843741",
         "qs_pg:id":1086171
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055893,
     "wof:geom_alt":[
@@ -233,7 +238,7 @@
         }
     ],
     "wof:id":890515155,
-    "wof:lastmodified":1694493385,
+    "wof:lastmodified":1695886063,
     "wof:name":"Nantong",
     "wof:parent_id":85669827,
     "wof:placetype":"county",

--- a/data/890/515/157/890515157.geojson
+++ b/data/890/515/157/890515157.geojson
@@ -247,8 +247,13 @@
         "gn:id":1804878,
         "gp:id":26198104,
         "hasc:id":"CN.HE.KF",
+        "meso:local_id":"73843816",
         "qs_pg:id":1086172
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055893,
     "wof:geom_alt":[
@@ -265,7 +270,7 @@
         }
     ],
     "wof:id":890515157,
-    "wof:lastmodified":1694493384,
+    "wof:lastmodified":1695886060,
     "wof:name":"Kaifeng",
     "wof:parent_id":85669801,
     "wof:placetype":"county",

--- a/data/890/515/159/890515159.geojson
+++ b/data/890/515/159/890515159.geojson
@@ -205,8 +205,13 @@
         "gn:id":1280931,
         "gp:id":26198132,
         "hasc:id":"CN.GS.JQ",
+        "meso:local_id":"73843994",
         "qs_pg:id":1086173
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055893,
     "wof:geom_alt":[
@@ -223,7 +228,7 @@
         }
     ],
     "wof:id":890515159,
-    "wof:lastmodified":1694493384,
+    "wof:lastmodified":1695886061,
     "wof:name":"Jiuquan",
     "wof:parent_id":85669711,
     "wof:placetype":"county",

--- a/data/890/515/163/890515163.geojson
+++ b/data/890/515/163/890515163.geojson
@@ -220,8 +220,13 @@
         "gn:id":1785035,
         "gp:id":26198133,
         "hasc:id":"CN.GS.ZY",
+        "meso:local_id":"73843819",
         "qs_pg:id":1086174
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055893,
     "wof:geom_alt":[
@@ -238,7 +243,7 @@
         }
     ],
     "wof:id":890515163,
-    "wof:lastmodified":1694493407,
+    "wof:lastmodified":1695886156,
     "wof:name":"Zhangye",
     "wof:parent_id":85669711,
     "wof:placetype":"county",

--- a/data/890/515/165/890515165.geojson
+++ b/data/890/515/165/890515165.geojson
@@ -169,8 +169,13 @@
         "gn:id":1809151,
         "gp:id":26198137,
         "hasc:id":"CN.NX.GY",
+        "meso:local_id":"73843768",
         "qs_pg:id":1086175
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055893,
     "wof:geom_alt":[
@@ -187,7 +192,7 @@
         }
     ],
     "wof:id":890515165,
-    "wof:lastmodified":1694493386,
+    "wof:lastmodified":1695886064,
     "wof:name":"Guyuan",
     "wof:parent_id":85669763,
     "wof:placetype":"county",

--- a/data/890/515/167/890515167.geojson
+++ b/data/890/515/167/890515167.geojson
@@ -193,8 +193,13 @@
         "gn:id":1797315,
         "gp:id":26198187,
         "hasc:id":"CN.YN.QJ",
+        "meso:local_id":"73843853",
         "qs_pg:id":1086176
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055893,
     "wof:geom_alt":[
@@ -211,7 +216,7 @@
         }
     ],
     "wof:id":890515167,
-    "wof:lastmodified":1694493384,
+    "wof:lastmodified":1695886061,
     "wof:name":"Qujing",
     "wof:parent_id":85669791,
     "wof:placetype":"county",

--- a/data/890/515/169/890515169.geojson
+++ b/data/890/515/169/890515169.geojson
@@ -199,8 +199,13 @@
         "gn:id":6642946,
         "gp:id":26198199,
         "hasc:id":"CN.SC.DY",
+        "meso:local_id":"73843823",
         "qs_pg:id":1086178
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055893,
     "wof:geom_alt":[
@@ -217,7 +222,7 @@
         }
     ],
     "wof:id":890515169,
-    "wof:lastmodified":1694493406,
+    "wof:lastmodified":1695886152,
     "wof:name":"Deyang",
     "wof:parent_id":85669787,
     "wof:placetype":"county",

--- a/data/890/515/171/890515171.geojson
+++ b/data/890/515/171/890515171.geojson
@@ -304,8 +304,13 @@
         "gn:id":1795266,
         "gp:id":26198255,
         "hasc:id":"CN.HB.SJ",
+        "meso:local_id":"73843937",
         "qs_pg:id":1086179
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055893,
     "wof:geom_alt":[
@@ -322,7 +327,7 @@
         }
     ],
     "wof:id":890515171,
-    "wof:lastmodified":1694493386,
+    "wof:lastmodified":1695886066,
     "wof:name":"Shijiazhuang",
     "wof:parent_id":85669797,
     "wof:placetype":"county",

--- a/data/890/515/173/890515173.geojson
+++ b/data/890/515/173/890515173.geojson
@@ -193,8 +193,13 @@
         "gn:id":1794892,
         "gp:id":26198265,
         "hasc:id":"CN.HU.SY",
+        "meso:local_id":"73843735",
         "qs_pg:id":1086180
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055893,
     "wof:geom_alt":[
@@ -211,7 +216,7 @@
         }
     ],
     "wof:id":890515173,
-    "wof:lastmodified":1694493407,
+    "wof:lastmodified":1695886155,
     "wof:name":"Shiyan",
     "wof:parent_id":85669777,
     "wof:placetype":"county",

--- a/data/890/515/175/890515175.geojson
+++ b/data/890/515/175/890515175.geojson
@@ -161,8 +161,10 @@
     "wof:concordances":{
         "gn:id":1529568,
         "gp:id":26198316,
+        "meso:local_id":"73843845",
         "qs_pg:id":1086184
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1469055893,
     "wof:geom_alt":[
@@ -179,7 +181,7 @@
         }
     ],
     "wof:id":890515175,
-    "wof:lastmodified":1694493386,
+    "wof:lastmodified":1695886064,
     "wof:name":"Changji",
     "wof:parent_id":85669753,
     "wof:placetype":"county",

--- a/data/890/515/189/890515189.geojson
+++ b/data/890/515/189/890515189.geojson
@@ -176,8 +176,13 @@
     "wof:concordances":{
         "gp:id":26198352,
         "hasc:id":"CN.GX.HZ",
+        "meso:local_id":"73843972",
         "qs_pg:id":1086440
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055894,
     "wof:geom_alt":[
@@ -194,7 +199,7 @@
         }
     ],
     "wof:id":890515189,
-    "wof:lastmodified":1694493385,
+    "wof:lastmodified":1695886063,
     "wof:name":"Hezhou",
     "wof:parent_id":85669717,
     "wof:placetype":"county",

--- a/data/890/515/199/890515199.geojson
+++ b/data/890/515/199/890515199.geojson
@@ -155,9 +155,14 @@
         "gn:id":2033412,
         "gp:id":26198062,
         "hasc:id":"CN.HL.YC",
+        "meso:local_id":"73843715",
         "qs_pg:id":10283,
         "wd:id":"Q635541"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055894,
     "wof:geom_alt":[
@@ -174,7 +179,7 @@
         }
     ],
     "wof:id":890515199,
-    "wof:lastmodified":1694493407,
+    "wof:lastmodified":1695886156,
     "wof:name":"Yichun",
     "wof:parent_id":85669849,
     "wof:placetype":"county",

--- a/data/890/515/239/890515239.geojson
+++ b/data/890/515/239/890515239.geojson
@@ -185,8 +185,13 @@
     "wof:concordances":{
         "gp:id":26198238,
         "hasc:id":"CN.AH.BZ",
+        "meso:local_id":"73843713",
         "qs_pg:id":1103979
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055896,
     "wof:geom_alt":[
@@ -203,7 +208,7 @@
         }
     ],
     "wof:id":890515239,
-    "wof:lastmodified":1694493386,
+    "wof:lastmodified":1695886066,
     "wof:name":"Bozhou",
     "wof:parent_id":85669739,
     "wof:placetype":"county",

--- a/data/890/515/379/890515379.geojson
+++ b/data/890/515/379/890515379.geojson
@@ -187,8 +187,13 @@
         "gn:id":1788505,
         "gp:id":26198156,
         "hasc:id":"CN.JX.XY",
+        "meso:local_id":"73843840",
         "qs_pg:id":47198
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055905,
     "wof:geom_alt":[
@@ -205,7 +210,7 @@
         }
     ],
     "wof:id":890515379,
-    "wof:lastmodified":1694493407,
+    "wof:lastmodified":1695886155,
     "wof:name":"Xinyu",
     "wof:parent_id":85669823,
     "wof:placetype":"county",

--- a/data/890/515/397/890515397.geojson
+++ b/data/890/515/397/890515397.geojson
@@ -166,9 +166,14 @@
         "gn:id":1529400,
         "gp:id":26198041,
         "hasc:id":"CN.XJ.KL",
+        "meso:local_id":"73843725",
         "qs_pg:id":1118952,
         "wd:id":"Q1365206"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055905,
     "wof:geom_alt":[
@@ -185,7 +190,7 @@
         }
     ],
     "wof:id":890515397,
-    "wof:lastmodified":1694493384,
+    "wof:lastmodified":1695886061,
     "wof:name":"Kelamayi",
     "wof:parent_id":85669753,
     "wof:placetype":"county",

--- a/data/890/515/419/890515419.geojson
+++ b/data/890/515/419/890515419.geojson
@@ -284,8 +284,13 @@
     "wof:concordances":{
         "gp:id":26198381,
         "hasc:id":"CN.GX.NN",
+        "meso:local_id":"73843738",
         "qs_pg:id":1121762
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055906,
     "wof:geom_alt":[
@@ -302,7 +307,7 @@
         }
     ],
     "wof:id":890515419,
-    "wof:lastmodified":1694493386,
+    "wof:lastmodified":1695886064,
     "wof:name":"Nanning",
     "wof:parent_id":85669717,
     "wof:placetype":"county",

--- a/data/890/515/625/890515625.geojson
+++ b/data/890/515/625/890515625.geojson
@@ -208,8 +208,13 @@
         "gn:id":1788571,
         "gp:id":26198369,
         "hasc:id":"CN.HE.XX",
+        "meso:local_id":"73843839",
         "qs_pg:id":61250
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055924,
     "wof:geom_alt":[
@@ -226,7 +231,7 @@
         }
     ],
     "wof:id":890515625,
-    "wof:lastmodified":1694493408,
+    "wof:lastmodified":1695886157,
     "wof:name":"Xinxiang",
     "wof:parent_id":85669801,
     "wof:placetype":"county",

--- a/data/890/515/627/890515627.geojson
+++ b/data/890/515/627/890515627.geojson
@@ -430,8 +430,13 @@
         "gn:id":1784657,
         "gp:id":26198373,
         "hasc:id":"CN.HE.ZZ",
+        "meso:local_id":"73843990",
         "qs_pg:id":61251
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055924,
     "wof:geom_alt":[
@@ -448,7 +453,7 @@
         }
     ],
     "wof:id":890515627,
-    "wof:lastmodified":1694493385,
+    "wof:lastmodified":1695886062,
     "wof:name":"Zhengzhou",
     "wof:parent_id":85669801,
     "wof:placetype":"county",

--- a/data/890/515/631/890515631.geojson
+++ b/data/890/515/631/890515631.geojson
@@ -262,8 +262,13 @@
         "gn:id":1801785,
         "gp:id":26198374,
         "hasc:id":"CN.HE.LY",
+        "meso:local_id":"73843887",
         "qs_pg:id":61252
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055924,
     "wof:geom_alt":[
@@ -280,7 +285,7 @@
         }
     ],
     "wof:id":890515631,
-    "wof:lastmodified":1694493386,
+    "wof:lastmodified":1695886066,
     "wof:name":"Luoyang",
     "wof:parent_id":85669801,
     "wof:placetype":"county",

--- a/data/890/515/633/890515633.geojson
+++ b/data/890/515/633/890515633.geojson
@@ -150,8 +150,13 @@
         "gn:id":1793504,
         "gp:id":26198375,
         "hasc:id":"CN.ZJ.TZ",
+        "meso:local_id":"73843746",
         "qs_pg:id":61253
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055924,
     "wof:geom_alt":[
@@ -168,7 +173,7 @@
         }
     ],
     "wof:id":890515633,
-    "wof:lastmodified":1694493406,
+    "wof:lastmodified":1695886153,
     "wof:name":"Taizhou",
     "wof:parent_id":85669835,
     "wof:placetype":"county",

--- a/data/890/515/671/890515671.geojson
+++ b/data/890/515/671/890515671.geojson
@@ -286,8 +286,13 @@
         "gn:id":1788850,
         "gp:id":26198289,
         "hasc:id":"CN.QH.XN",
+        "meso:local_id":"73843967",
         "qs_pg:id":1150470
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055925,
     "wof:geom_alt":[
@@ -304,7 +309,7 @@
         }
     ],
     "wof:id":890515671,
-    "wof:lastmodified":1694493386,
+    "wof:lastmodified":1695886065,
     "wof:name":"Xining",
     "wof:parent_id":85669715,
     "wof:placetype":"county",

--- a/data/890/515/687/890515687.geojson
+++ b/data/890/515/687/890515687.geojson
@@ -356,8 +356,13 @@
     "wof:concordances":{
         "gp:id":26198119,
         "hasc:id":"CN.SA.XA",
+        "meso:local_id":"73843968",
         "qs_pg:id":1154631
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055926,
     "wof:geom_alt":[
@@ -374,7 +379,7 @@
         }
     ],
     "wof:id":890515687,
-    "wof:lastmodified":1694493385,
+    "wof:lastmodified":1695886062,
     "wof:name":"Xi'an",
     "wof:parent_id":85669769,
     "wof:placetype":"county",

--- a/data/890/515/689/890515689.geojson
+++ b/data/890/515/689/890515689.geojson
@@ -200,8 +200,13 @@
     "wof:concordances":{
         "gp:id":26198120,
         "hasc:id":"CN.SA.XY",
+        "meso:local_id":"73843758",
         "qs_pg:id":1154634
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055926,
     "wof:geom_alt":[
@@ -218,7 +223,7 @@
         }
     ],
     "wof:id":890515689,
-    "wof:lastmodified":1694493406,
+    "wof:lastmodified":1695886152,
     "wof:name":"Xianyang",
     "wof:parent_id":85669769,
     "wof:placetype":"county",

--- a/data/890/515/829/890515829.geojson
+++ b/data/890/515/829/890515829.geojson
@@ -193,8 +193,13 @@
         "gn:id":2035260,
         "gp:id":26198060,
         "hasc:id":"CN.HL.QT",
+        "meso:local_id":"73843684",
         "qs_pg:id":1182272
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055932,
     "wof:geom_alt":[
@@ -211,7 +216,7 @@
         }
     ],
     "wof:id":890515829,
-    "wof:lastmodified":1694493406,
+    "wof:lastmodified":1695886152,
     "wof:name":"Qitaihe",
     "wof:parent_id":85669849,
     "wof:placetype":"county",

--- a/data/890/515/831/890515831.geojson
+++ b/data/890/515/831/890515831.geojson
@@ -214,8 +214,10 @@
     "wof:concordances":{
         "gn:id":1816439,
         "gp:id":26198097,
+        "meso:local_id":"73843961",
         "qs_pg:id":1182273
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1469055933,
     "wof:geom_alt":[
@@ -232,7 +234,7 @@
         }
     ],
     "wof:id":890515831,
-    "wof:lastmodified":1694493408,
+    "wof:lastmodified":1695886157,
     "wof:name":"Bengbu",
     "wof:parent_id":85669739,
     "wof:placetype":"county",

--- a/data/890/515/833/890515833.geojson
+++ b/data/890/515/833/890515833.geojson
@@ -206,8 +206,13 @@
         "gn:id":1793722,
         "gp:id":26198299,
         "hasc:id":"CN.SD.TA",
+        "meso:local_id":"73843884",
         "qs_pg:id":1184155
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055933,
     "wof:geom_alt":[
@@ -224,7 +229,7 @@
         }
     ],
     "wof:id":890515833,
-    "wof:lastmodified":1694493385,
+    "wof:lastmodified":1695886063,
     "wof:name":"Tai'an",
     "wof:parent_id":85669813,
     "wof:placetype":"county",

--- a/data/890/515/835/890515835.geojson
+++ b/data/890/515/835/890515835.geojson
@@ -205,8 +205,13 @@
         "gn:id":1805986,
         "gp:id":26198371,
         "hasc:id":"CN.HE.JZ",
+        "meso:local_id":"73843917",
         "qs_pg:id":1184197
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055933,
     "wof:geom_alt":[
@@ -223,7 +228,7 @@
         }
     ],
     "wof:id":890515835,
-    "wof:lastmodified":1694493406,
+    "wof:lastmodified":1695886153,
     "wof:name":"Jiaozuo",
     "wof:parent_id":85669801,
     "wof:placetype":"county",

--- a/data/890/515/843/890515843.geojson
+++ b/data/890/515/843/890515843.geojson
@@ -196,8 +196,13 @@
         "gn:id":6571356,
         "gp:id":26198170,
         "hasc:id":"CN.GD.SW",
+        "meso:local_id":"73843876",
         "qs_pg:id":355037
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055933,
     "wof:geom_alt":[
@@ -214,7 +219,7 @@
         }
     ],
     "wof:id":890515843,
-    "wof:lastmodified":1694493385,
+    "wof:lastmodified":1695886062,
     "wof:name":"Shanwei",
     "wof:parent_id":85669743,
     "wof:placetype":"county",

--- a/data/890/515/847/890515847.geojson
+++ b/data/890/515/847/890515847.geojson
@@ -208,8 +208,13 @@
         "gn:id":1783744,
         "gp:id":26198204,
         "hasc:id":"CN.SC.ZG",
+        "meso:local_id":"73843948",
         "qs_pg:id":355094
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055933,
     "wof:geom_alt":[
@@ -226,7 +231,7 @@
         }
     ],
     "wof:id":890515847,
-    "wof:lastmodified":1694493408,
+    "wof:lastmodified":1695886157,
     "wof:name":"Zigong",
     "wof:parent_id":85669787,
     "wof:placetype":"county",

--- a/data/890/515/867/890515867.geojson
+++ b/data/890/515/867/890515867.geojson
@@ -211,8 +211,13 @@
         "gn:id":1815761,
         "gp:id":26198209,
         "hasc:id":"CN.HN.CD",
+        "meso:local_id":"73843806",
         "qs_pg:id":890386
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055934,
     "wof:geom_alt":[
@@ -229,7 +234,7 @@
         }
     ],
     "wof:id":890515867,
-    "wof:lastmodified":1694493407,
+    "wof:lastmodified":1695886154,
     "wof:name":"Changde",
     "wof:parent_id":85669781,
     "wof:placetype":"county",

--- a/data/890/515/869/890515869.geojson
+++ b/data/890/515/869/890515869.geojson
@@ -202,8 +202,13 @@
         "gn:id":1796129,
         "gp:id":26198281,
         "hasc:id":"CN.JX.SR",
+        "meso:local_id":"73843690",
         "qs_pg:id":890394
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055934,
     "wof:geom_alt":[
@@ -220,7 +225,7 @@
         }
     ],
     "wof:id":890515869,
-    "wof:lastmodified":1694493407,
+    "wof:lastmodified":1695886154,
     "wof:name":"Shangrao",
     "wof:parent_id":85669823,
     "wof:placetype":"county",

--- a/data/890/515/871/890515871.geojson
+++ b/data/890/515/871/890515871.geojson
@@ -368,8 +368,13 @@
         "gn:id":1809051,
         "gp:id":26198288,
         "hasc:id":"CN.HA.HN",
+        "meso:local_id":"73843892",
         "qs_pg:id":890395
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055934,
     "wof:geom_alt":[
@@ -386,7 +391,7 @@
         }
     ],
     "wof:id":890515871,
-    "wof:lastmodified":1694493386,
+    "wof:lastmodified":1695886065,
     "wof:name":"Hainan",
     "wof:parent_id":85669715,
     "wof:placetype":"county",

--- a/data/890/515/873/890515873.geojson
+++ b/data/890/515/873/890515873.geojson
@@ -103,8 +103,13 @@
         "gn:id":1809111,
         "gp:id":26198290,
         "hasc:id":"CN.QH.HB",
+        "meso:local_id":"73843891",
         "qs_pg:id":890396
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055934,
     "wof:geom_alt":[
@@ -121,7 +126,7 @@
         }
     ],
     "wof:id":890515873,
-    "wof:lastmodified":1694493389,
+    "wof:lastmodified":1695886496,
     "wof:name":"Haibei",
     "wof:parent_id":85669715,
     "wof:placetype":"county",

--- a/data/890/515/875/890515875.geojson
+++ b/data/890/515/875/890515875.geojson
@@ -205,8 +205,13 @@
         "gn:id":1805517,
         "gp:id":26198300,
         "hasc:id":"CN.SD.JN",
+        "meso:local_id":"73843889",
         "qs_pg:id":890397
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055934,
     "wof:geom_alt":[
@@ -223,7 +228,7 @@
         }
     ],
     "wof:id":890515875,
-    "wof:lastmodified":1694493406,
+    "wof:lastmodified":1695886153,
     "wof:name":"Jining",
     "wof:parent_id":85669813,
     "wof:placetype":"county",

--- a/data/890/515/877/890515877.geojson
+++ b/data/890/515/877/890515877.geojson
@@ -134,8 +134,13 @@
         "gn:id":1280735,
         "gp:id":26198235,
         "hasc:id":"CN.XZ.LS",
+        "meso:local_id":"73843834",
         "qs_pg:id":890398
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055934,
     "wof:geom_alt":[
@@ -152,7 +157,7 @@
         }
     ],
     "wof:id":890515877,
-    "wof:lastmodified":1694493386,
+    "wof:lastmodified":1695886066,
     "wof:name":"Lasa",
     "wof:parent_id":85669747,
     "wof:placetype":"county",

--- a/data/890/515/879/890515879.geojson
+++ b/data/890/515/879/890515879.geojson
@@ -301,8 +301,13 @@
         "gn:id":1881771,
         "gp:id":26198274,
         "hasc:id":"CN.JS.SZ",
+        "meso:local_id":"73843951",
         "qs_pg:id":890399
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055934,
     "wof:geom_alt":[
@@ -319,7 +324,7 @@
         }
     ],
     "wof:id":890515879,
-    "wof:lastmodified":1694493408,
+    "wof:lastmodified":1695886157,
     "wof:name":"Suzhou",
     "wof:parent_id":85669827,
     "wof:placetype":"county",

--- a/data/890/515/891/890515891.geojson
+++ b/data/890/515/891/890515891.geojson
@@ -313,8 +313,13 @@
         "gn:id":1814068,
         "gp:id":26198070,
         "hasc:id":"CN.LN.DL",
+        "meso:local_id":"73843775",
         "qs_pg:id":898920
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055934,
     "wof:geom_alt":[
@@ -331,7 +336,7 @@
         }
     ],
     "wof:id":890515891,
-    "wof:lastmodified":1694493387,
+    "wof:lastmodified":1695886066,
     "wof:name":"Dalian",
     "wof:parent_id":85669807,
     "wof:placetype":"county",

--- a/data/890/515/907/890515907.geojson
+++ b/data/890/515/907/890515907.geojson
@@ -145,8 +145,13 @@
         "gn:id":2038101,
         "gp:id":26198073,
         "hasc:id":"CN.LN.CY",
+        "meso:local_id":"73843855",
         "qs_pg:id":10284
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055935,
     "wof:geom_alt":[
@@ -163,7 +168,7 @@
         }
     ],
     "wof:id":890515907,
-    "wof:lastmodified":1694493406,
+    "wof:lastmodified":1695886152,
     "wof:name":"Chaoyang",
     "wof:parent_id":85669807,
     "wof:placetype":"county",

--- a/data/890/515/909/890515909.geojson
+++ b/data/890/515/909/890515909.geojson
@@ -203,8 +203,13 @@
         "gn:id":1803833,
         "gp:id":26198089,
         "hasc:id":"CN.SD.LC",
+        "meso:local_id":"73843946",
         "qs_pg:id":47132
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055935,
     "wof:geom_alt":[
@@ -221,7 +226,7 @@
         }
     ],
     "wof:id":890515909,
-    "wof:lastmodified":1694493406,
+    "wof:lastmodified":1695886152,
     "wof:name":"Liaocheng",
     "wof:parent_id":85669813,
     "wof:placetype":"county",

--- a/data/890/515/915/890515915.geojson
+++ b/data/890/515/915/890515915.geojson
@@ -214,8 +214,13 @@
         "gn:id":2035713,
         "gp:id":26198059,
         "hasc:id":"CN.HL.MD",
+        "meso:local_id":"73843918",
         "qs_pg:id":1118953
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055935,
     "wof:geom_alt":[
@@ -232,7 +237,7 @@
         }
     ],
     "wof:id":890515915,
-    "wof:lastmodified":1694493385,
+    "wof:lastmodified":1695886063,
     "wof:name":"Mudanjiang",
     "wof:parent_id":85669849,
     "wof:placetype":"county",

--- a/data/890/515/951/890515951.geojson
+++ b/data/890/515/951/890515951.geojson
@@ -92,8 +92,13 @@
     "wof:concordances":{
         "gp:id":26198303,
         "hasc:id":"CN.XZ.LZ",
+        "meso:local_id":"73843860",
         "qs_pg:id":358259
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055937,
     "wof:geom_alt":[
@@ -110,7 +115,7 @@
         }
     ],
     "wof:id":890515951,
-    "wof:lastmodified":1694493391,
+    "wof:lastmodified":1695886501,
     "wof:name":"Linzhi",
     "wof:parent_id":85669747,
     "wof:placetype":"county",

--- a/data/890/516/201/890516201.geojson
+++ b/data/890/516/201/890516201.geojson
@@ -232,8 +232,13 @@
         "gn:id":1817991,
         "gp:id":26198216,
         "hasc:id":"CN.AH.AQ",
+        "meso:local_id":"73843785",
         "qs_pg:id":1287937
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055948,
     "wof:geom_alt":[
@@ -250,7 +255,7 @@
         }
     ],
     "wof:id":890516201,
-    "wof:lastmodified":1694493399,
+    "wof:lastmodified":1695886133,
     "wof:name":"Anqing",
     "wof:parent_id":85669739,
     "wof:placetype":"county",

--- a/data/890/516/203/890516203.geojson
+++ b/data/890/516/203/890516203.geojson
@@ -202,8 +202,13 @@
         "gn:id":1802274,
         "gp:id":26198337,
         "hasc:id":"CN.FJ.LY",
+        "meso:local_id":"73844043",
         "qs_pg:id":1287993
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055948,
     "wof:geom_alt":[
@@ -220,7 +225,7 @@
         }
     ],
     "wof:id":890516203,
-    "wof:lastmodified":1694493398,
+    "wof:lastmodified":1695886129,
     "wof:name":"Longyan",
     "wof:parent_id":85669735,
     "wof:placetype":"county",

--- a/data/890/516/233/890516233.geojson
+++ b/data/890/516/233/890516233.geojson
@@ -232,8 +232,13 @@
         "gn:id":1807680,
         "gp:id":26198098,
         "hasc:id":"CN.AH.HN",
+        "meso:local_id":"73843897",
         "qs_pg:id":354965
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055949,
     "wof:geom_alt":[
@@ -250,7 +255,7 @@
         }
     ],
     "wof:id":890516233,
-    "wof:lastmodified":1694493398,
+    "wof:lastmodified":1695886130,
     "wof:name":"Huainan",
     "wof:parent_id":85669739,
     "wof:placetype":"county",

--- a/data/890/516/235/890516235.geojson
+++ b/data/890/516/235/890516235.geojson
@@ -104,8 +104,13 @@
         "gn:id":2037012,
         "gp:id":26198257,
         "hasc:id":"CN.HL.HB",
+        "meso:local_id":"73843760",
         "qs_pg:id":355168
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055949,
     "wof:geom_alt":[
@@ -122,7 +127,7 @@
         }
     ],
     "wof:id":890516235,
-    "wof:lastmodified":1694493389,
+    "wof:lastmodified":1695886497,
     "wof:name":"Ha'erbin",
     "wof:parent_id":85669849,
     "wof:placetype":"county",

--- a/data/890/516/237/890516237.geojson
+++ b/data/890/516/237/890516237.geojson
@@ -148,8 +148,13 @@
         "gn:id":1793502,
         "gp:id":26198277,
         "hasc:id":"CN.JS.TZ",
+        "meso:local_id":"73843885",
         "qs_pg:id":355202
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055949,
     "wof:geom_alt":[
@@ -166,7 +171,7 @@
         }
     ],
     "wof:id":890516237,
-    "wof:lastmodified":1694493399,
+    "wof:lastmodified":1695886133,
     "wof:name":"Taizhou",
     "wof:parent_id":85669827,
     "wof:placetype":"county",

--- a/data/890/516/247/890516247.geojson
+++ b/data/890/516/247/890516247.geojson
@@ -193,8 +193,13 @@
         "gn:id":1801930,
         "gp:id":26198108,
         "hasc:id":"CN.HE.LH",
+        "meso:local_id":"73843909",
         "qs_pg:id":1201234
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055950,
     "wof:geom_alt":[
@@ -211,7 +216,7 @@
         }
     ],
     "wof:id":890516247,
-    "wof:lastmodified":1694493398,
+    "wof:lastmodified":1695886131,
     "wof:name":"Luohe",
     "wof:parent_id":85669801,
     "wof:placetype":"county",

--- a/data/890/516/249/890516249.geojson
+++ b/data/890/516/249/890516249.geojson
@@ -193,8 +193,13 @@
         "gn:id":2034413,
         "gp:id":26198225,
         "hasc:id":"CN.JL.TH",
+        "meso:local_id":"73843982",
         "qs_pg:id":428052
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055950,
     "wof:geom_alt":[
@@ -211,7 +216,7 @@
         }
     ],
     "wof:id":890516249,
-    "wof:lastmodified":1694493398,
+    "wof:lastmodified":1695886132,
     "wof:name":"Tonghua",
     "wof:parent_id":85669843,
     "wof:placetype":"county",

--- a/data/890/516/251/890516251.geojson
+++ b/data/890/516/251/890516251.geojson
@@ -100,8 +100,13 @@
         "gn:id":1529101,
         "gp:id":26198317,
         "hasc:id":"CN.XJ.WL",
+        "meso:local_id":"73843706",
         "qs_pg:id":428053
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055950,
     "wof:geom_alt":[
@@ -118,7 +123,7 @@
         }
     ],
     "wof:id":890516251,
-    "wof:lastmodified":1694493393,
+    "wof:lastmodified":1695886505,
     "wof:name":"Wulumuqi",
     "wof:parent_id":85669753,
     "wof:placetype":"county",

--- a/data/890/516/253/890516253.geojson
+++ b/data/890/516/253/890516253.geojson
@@ -205,8 +205,13 @@
         "gn:id":1798759,
         "gp:id":26198351,
         "hasc:id":"CN.GS.PL",
+        "meso:local_id":"73843807",
         "qs_pg:id":428083
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055950,
     "wof:geom_alt":[
@@ -223,7 +228,7 @@
         }
     ],
     "wof:id":890516253,
-    "wof:lastmodified":1694493399,
+    "wof:lastmodified":1695886133,
     "wof:name":"Pingliang",
     "wof:parent_id":85669711,
     "wof:placetype":"county",

--- a/data/890/516/301/890516301.geojson
+++ b/data/890/516/301/890516301.geojson
@@ -220,8 +220,13 @@
         "gn:id":1787083,
         "gp:id":26198080,
         "hasc:id":"CN.SD.YT",
+        "meso:local_id":"73843916",
         "qs_pg:id":192703
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055951,
     "wof:geom_alt":[
@@ -238,7 +243,7 @@
         }
     ],
     "wof:id":890516301,
-    "wof:lastmodified":1694493375,
+    "wof:lastmodified":1695886036,
     "wof:name":"Yantai",
     "wof:parent_id":85669813,
     "wof:placetype":"county",

--- a/data/890/516/323/890516323.geojson
+++ b/data/890/516/323/890516323.geojson
@@ -211,8 +211,13 @@
         "gn:id":1784313,
         "gp:id":26198046,
         "hasc:id":"CN.GD.ZS",
+        "meso:local_id":"73843695",
         "qs_pg:id":203457
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055953,
     "wof:geom_alt":[
@@ -229,7 +234,7 @@
         }
     ],
     "wof:id":890516323,
-    "wof:lastmodified":1694493375,
+    "wof:lastmodified":1695886039,
     "wof:name":"Zhongshan",
     "wof:parent_id":85669743,
     "wof:placetype":"county",

--- a/data/890/516/325/890516325.geojson
+++ b/data/890/516/325/890516325.geojson
@@ -322,8 +322,13 @@
         "gn:id":1805751,
         "gp:id":26198085,
         "hasc:id":"CN.SD.JI",
+        "meso:local_id":"73843888",
         "qs_pg:id":203458
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055953,
     "wof:geom_alt":[
@@ -340,7 +345,7 @@
         }
     ],
     "wof:id":890516325,
-    "wof:lastmodified":1694493376,
+    "wof:lastmodified":1695886040,
     "wof:name":"Jinan",
     "wof:parent_id":85669813,
     "wof:placetype":"county",

--- a/data/890/516/327/890516327.geojson
+++ b/data/890/516/327/890516327.geojson
@@ -202,8 +202,13 @@
         "gn:id":1785450,
         "gp:id":26198084,
         "hasc:id":"CN.SD.ZZ",
+        "meso:local_id":"73843862",
         "qs_pg:id":203459
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055953,
     "wof:geom_alt":[
@@ -220,7 +225,7 @@
         }
     ],
     "wof:id":890516327,
-    "wof:lastmodified":1694493399,
+    "wof:lastmodified":1695886134,
     "wof:name":"Zaozhuang",
     "wof:parent_id":85669813,
     "wof:placetype":"county",

--- a/data/890/516/329/890516329.geojson
+++ b/data/890/516/329/890516329.geojson
@@ -205,8 +205,13 @@
         "gn:id":1805747,
         "gp:id":26198056,
         "hasc:id":"CN.GS.JC",
+        "meso:local_id":"73843997",
         "qs_pg:id":203460
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055953,
     "wof:geom_alt":[
@@ -223,7 +228,7 @@
         }
     ],
     "wof:id":890516329,
-    "wof:lastmodified":1694493399,
+    "wof:lastmodified":1695886134,
     "wof:name":"Jinchang",
     "wof:parent_id":85669711,
     "wof:placetype":"county",

--- a/data/890/516/333/890516333.geojson
+++ b/data/890/516/333/890516333.geojson
@@ -222,8 +222,13 @@
         "gn:id":1787823,
         "gp:id":26198090,
         "hasc:id":"CN.JS.XZ",
+        "meso:local_id":"73843820",
         "qs_pg:id":203466
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055953,
     "wof:geom_alt":[
@@ -240,7 +245,7 @@
         }
     ],
     "wof:id":890516333,
-    "wof:lastmodified":1694493377,
+    "wof:lastmodified":1695886043,
     "wof:name":"Xuzhou",
     "wof:parent_id":85669827,
     "wof:placetype":"county",

--- a/data/890/516/335/890516335.geojson
+++ b/data/890/516/335/890516335.geojson
@@ -184,8 +184,13 @@
         "gn:id":1802494,
         "gp:id":26198124,
         "hasc:id":"CN.GS.LN",
+        "meso:local_id":"73844021",
         "qs_pg:id":203467
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055953,
     "wof:geom_alt":[
@@ -202,7 +207,7 @@
         }
     ],
     "wof:id":890516335,
-    "wof:lastmodified":1694493377,
+    "wof:lastmodified":1695886042,
     "wof:name":"Longnan",
     "wof:parent_id":85669711,
     "wof:placetype":"county",

--- a/data/890/516/337/890516337.geojson
+++ b/data/890/516/337/890516337.geojson
@@ -196,8 +196,13 @@
         "gn:id":1812743,
         "gp:id":26198127,
         "hasc:id":"CN.GS.DX",
+        "meso:local_id":"73843790",
         "qs_pg:id":203468
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055953,
     "wof:geom_alt":[
@@ -214,7 +219,7 @@
         }
     ],
     "wof:id":890516337,
-    "wof:lastmodified":1694493374,
+    "wof:lastmodified":1695886036,
     "wof:name":"Dingxi",
     "wof:parent_id":85669711,
     "wof:placetype":"county",

--- a/data/890/516/339/890516339.geojson
+++ b/data/890/516/339/890516339.geojson
@@ -127,8 +127,13 @@
         "gn:id":1799614,
         "gp:id":26198256,
         "hasc:id":"CN.HE.NY",
+        "meso:local_id":"73843742",
         "qs_pg:id":203471
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055953,
     "wof:geom_alt":[
@@ -145,7 +150,7 @@
         }
     ],
     "wof:id":890516339,
-    "wof:lastmodified":1694493397,
+    "wof:lastmodified":1695886127,
     "wof:name":"Nanyang",
     "wof:parent_id":85669801,
     "wof:placetype":"county",

--- a/data/890/516/341/890516341.geojson
+++ b/data/890/516/341/890516341.geojson
@@ -91,8 +91,10 @@
     "wof:concordances":{
         "gn:id":1806529,
         "gp:id":26198286,
+        "meso:local_id":"73843992",
         "qs_pg:id":203472
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CN",
     "wof:created":1469055953,
     "wof:geom_alt":[
@@ -109,7 +111,7 @@
         }
     ],
     "wof:id":890516341,
-    "wof:lastmodified":1694493391,
+    "wof:lastmodified":1695886501,
     "wof:name":"E'erduosi",
     "wof:parent_id":85669847,
     "wof:placetype":"county",

--- a/data/890/516/343/890516343.geojson
+++ b/data/890/516/343/890516343.geojson
@@ -235,8 +235,13 @@
         "gn:id":1783950,
         "gp:id":26198347,
         "hasc:id":"CN.GD.ZH",
+        "meso:local_id":"73843922",
         "qs_pg:id":203480
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055953,
     "wof:geom_alt":[
@@ -253,7 +258,7 @@
         }
     ],
     "wof:id":890516343,
-    "wof:lastmodified":1694493377,
+    "wof:lastmodified":1695886045,
     "wof:name":"Zhuhai",
     "wof:parent_id":85669743,
     "wof:placetype":"county",

--- a/data/890/516/345/890516345.geojson
+++ b/data/890/516/345/890516345.geojson
@@ -208,8 +208,13 @@
         "gn:id":1787530,
         "gp:id":26198348,
         "hasc:id":"CN.GD.YJ",
+        "meso:local_id":"73844013",
         "qs_pg:id":203481
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055954,
     "wof:geom_alt":[
@@ -226,7 +231,7 @@
         }
     ],
     "wof:id":890516345,
-    "wof:lastmodified":1694493399,
+    "wof:lastmodified":1695886134,
     "wof:name":"Yangjiang",
     "wof:parent_id":85669743,
     "wof:placetype":"county",

--- a/data/890/516/355/890516355.geojson
+++ b/data/890/516/355/890516355.geojson
@@ -166,9 +166,14 @@
         "gn:id":6643373,
         "gp:id":26198296,
         "hasc:id":"CN.SC.GA",
+        "meso:local_id":"73843810",
         "qs_pg:id":206441,
         "wd:id":"Q895927"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055954,
     "wof:geom_alt":[
@@ -185,7 +190,7 @@
         }
     ],
     "wof:id":890516355,
-    "wof:lastmodified":1694493375,
+    "wof:lastmodified":1695886037,
     "wof:name":"Guang'an",
     "wof:parent_id":85669787,
     "wof:placetype":"county",

--- a/data/890/516/395/890516395.geojson
+++ b/data/890/516/395/890516395.geojson
@@ -197,9 +197,14 @@
     "wof:concordances":{
         "gp:id":26198320,
         "hasc:id":"CN.XZ.RK",
+        "meso:local_id":"73843842",
         "qs_pg:id":889904,
         "wd:id":"Q116656"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055955,
     "wof:geom_alt":[
@@ -216,7 +221,7 @@
         }
     ],
     "wof:id":890516395,
-    "wof:lastmodified":1694493376,
+    "wof:lastmodified":1695886040,
     "wof:name":"Rikaze",
     "wof:parent_id":85669747,
     "wof:placetype":"county",

--- a/data/890/516/397/890516397.geojson
+++ b/data/890/516/397/890516397.geojson
@@ -229,8 +229,13 @@
         "gn:id":1787226,
         "gp:id":26198278,
         "hasc:id":"CN.JS.YZ",
+        "meso:local_id":"73843830",
         "qs_pg:id":890393
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055955,
     "wof:geom_alt":[
@@ -247,7 +252,7 @@
         }
     ],
     "wof:id":890516397,
-    "wof:lastmodified":1694493375,
+    "wof:lastmodified":1695886037,
     "wof:name":"Yangzhou",
     "wof:parent_id":85669827,
     "wof:placetype":"county",

--- a/data/890/516/399/890516399.geojson
+++ b/data/890/516/399/890516399.geojson
@@ -199,8 +199,13 @@
         "gn:id":1803243,
         "gp:id":26198326,
         "hasc:id":"CN.ZJ.LS",
+        "meso:local_id":"73843702",
         "qs_pg:id":891421
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055956,
     "wof:geom_alt":[
@@ -217,7 +222,7 @@
         }
     ],
     "wof:id":890516399,
-    "wof:lastmodified":1694493397,
+    "wof:lastmodified":1695886127,
     "wof:name":"Lishui",
     "wof:parent_id":85669835,
     "wof:placetype":"county",

--- a/data/890/516/401/890516401.geojson
+++ b/data/890/516/401/890516401.geojson
@@ -268,8 +268,13 @@
         "gn:id":1812532,
         "gp:id":26198345,
         "hasc:id":"CN.GD.DG",
+        "meso:local_id":"73843692",
         "qs_pg:id":891424
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055956,
     "wof:geom_alt":[
@@ -286,7 +291,7 @@
         }
     ],
     "wof:id":890516401,
-    "wof:lastmodified":1694493375,
+    "wof:lastmodified":1695886038,
     "wof:name":"Dongguan",
     "wof:parent_id":85669743,
     "wof:placetype":"county",

--- a/data/890/516/409/890516409.geojson
+++ b/data/890/516/409/890516409.geojson
@@ -184,8 +184,13 @@
         "gn:id":1802234,
         "gp:id":26198165,
         "hasc:id":"CN.HN.LD",
+        "meso:local_id":"73843781",
         "qs_pg:id":894114
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055956,
     "wof:geom_alt":[
@@ -202,7 +207,7 @@
         }
     ],
     "wof:id":890516409,
-    "wof:lastmodified":1694493375,
+    "wof:lastmodified":1695886039,
     "wof:name":"Loudi",
     "wof:parent_id":85669781,
     "wof:placetype":"county",

--- a/data/890/516/415/890516415.geojson
+++ b/data/890/516/415/890516415.geojson
@@ -232,8 +232,13 @@
         "gn:id":2037794,
         "gp:id":26198304,
         "hasc:id":"CN.SX.DT",
+        "meso:local_id":"73843772",
         "qs_pg:id":896550
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055956,
     "wof:geom_alt":[
@@ -250,7 +255,7 @@
         }
     ],
     "wof:id":890516415,
-    "wof:lastmodified":1694493398,
+    "wof:lastmodified":1695886129,
     "wof:name":"Datong",
     "wof:parent_id":85669773,
     "wof:placetype":"county",

--- a/data/890/516/425/890516425.geojson
+++ b/data/890/516/425/890516425.geojson
@@ -431,8 +431,13 @@
         "gn:id":1799960,
         "gp:id":26198099,
         "hasc:id":"CN.JS.NJ",
+        "meso:local_id":"73843736",
         "qs_pg:id":897154
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055957,
     "wof:geom_alt":[
@@ -449,7 +454,7 @@
         }
     ],
     "wof:id":890516425,
-    "wof:lastmodified":1694493375,
+    "wof:lastmodified":1695886037,
     "wof:name":"Nanjing",
     "wof:parent_id":85669827,
     "wof:placetype":"county",

--- a/data/890/516/465/890516465.geojson
+++ b/data/890/516/465/890516465.geojson
@@ -155,9 +155,14 @@
         "gn:id":1817238,
         "gp:id":26198130,
         "hasc:id":"CN.GS.BY",
+        "meso:local_id":"73843930",
         "qs_pg:id":212438,
         "wd:id":"Q804044"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055960,
     "wof:geom_alt":[
@@ -174,7 +179,7 @@
         }
     ],
     "wof:id":890516465,
-    "wof:lastmodified":1694493375,
+    "wof:lastmodified":1695886039,
     "wof:name":"Baiyin",
     "wof:parent_id":85669711,
     "wof:placetype":"county",

--- a/data/890/516/467/890516467.geojson
+++ b/data/890/516/467/890516467.geojson
@@ -136,8 +136,13 @@
         "gn:id":1790930,
         "gp:id":26198131,
         "hasc:id":"CN.GS.WW",
+        "meso:local_id":"73843870",
         "qs_pg:id":212439
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055960,
     "wof:geom_alt":[
@@ -154,7 +159,7 @@
         }
     ],
     "wof:id":890516467,
-    "wof:lastmodified":1694493399,
+    "wof:lastmodified":1695886133,
     "wof:name":"Wuwei",
     "wof:parent_id":85669711,
     "wof:placetype":"county",

--- a/data/890/516/469/890516469.geojson
+++ b/data/890/516/469/890516469.geojson
@@ -310,8 +310,13 @@
         "gn:id":1800160,
         "gp:id":26198151,
         "hasc:id":"CN.JX.NC",
+        "meso:local_id":"73843740",
         "qs_pg:id":212440
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055960,
     "wof:geom_alt":[
@@ -328,7 +333,7 @@
         }
     ],
     "wof:id":890516469,
-    "wof:lastmodified":1694493377,
+    "wof:lastmodified":1695886044,
     "wof:name":"Nanchang",
     "wof:parent_id":85669823,
     "wof:placetype":"county",

--- a/data/890/516/473/890516473.geojson
+++ b/data/890/516/473/890516473.geojson
@@ -146,9 +146,14 @@
         "gn:id":1783620,
         "gp:id":26198206,
         "hasc:id":"CN.GZ.ZY",
+        "meso:local_id":"73843985",
         "qs_pg:id":212442,
         "wd:id":"Q230182"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055960,
     "wof:geom_alt":[
@@ -165,7 +170,7 @@
         }
     ],
     "wof:id":890516473,
-    "wof:lastmodified":1694493399,
+    "wof:lastmodified":1695886132,
     "wof:name":"Zunyi",
     "wof:parent_id":85669721,
     "wof:placetype":"county",

--- a/data/890/516/477/890516477.geojson
+++ b/data/890/516/477/890516477.geojson
@@ -202,8 +202,13 @@
         "gn:id":1786419,
         "gp:id":26198208,
         "hasc:id":"CN.HN.YI",
+        "meso:local_id":"73843932",
         "qs_pg:id":212443
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055960,
     "wof:geom_alt":[
@@ -220,7 +225,7 @@
         }
     ],
     "wof:id":890516477,
-    "wof:lastmodified":1694493397,
+    "wof:lastmodified":1695886128,
     "wof:name":"Yiyang",
     "wof:parent_id":85669781,
     "wof:placetype":"county",

--- a/data/890/516/479/890516479.geojson
+++ b/data/890/516/479/890516479.geojson
@@ -211,8 +211,13 @@
         "gn:id":1785881,
         "gp:id":26198212,
         "hasc:id":"CN.HN.YU",
+        "meso:local_id":"73843800",
         "qs_pg:id":212446
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055960,
     "wof:geom_alt":[
@@ -229,7 +234,7 @@
         }
     ],
     "wof:id":890516479,
-    "wof:lastmodified":1694493397,
+    "wof:lastmodified":1695886128,
     "wof:name":"Yueyang",
     "wof:parent_id":85669781,
     "wof:placetype":"county",

--- a/data/890/516/481/890516481.geojson
+++ b/data/890/516/481/890516481.geojson
@@ -214,8 +214,13 @@
         "gn:id":2033194,
         "gp:id":26198252,
         "hasc:id":"CN.HB.ZJ",
+        "meso:local_id":"73843817",
         "qs_pg:id":212447
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055960,
     "wof:geom_alt":[
@@ -232,7 +237,7 @@
         }
     ],
     "wof:id":890516481,
-    "wof:lastmodified":1694493398,
+    "wof:lastmodified":1695886131,
     "wof:name":"Zhangjiakou",
     "wof:parent_id":85669797,
     "wof:placetype":"county",

--- a/data/890/516/483/890516483.geojson
+++ b/data/890/516/483/890516483.geojson
@@ -106,8 +106,13 @@
         "gn:id":2035264,
         "gp:id":26198259,
         "hasc:id":"CN.HL.QQ",
+        "meso:local_id":"73844042",
         "qs_pg:id":212448
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055960,
     "wof:geom_alt":[
@@ -124,7 +129,7 @@
         }
     ],
     "wof:id":890516483,
-    "wof:lastmodified":1694493393,
+    "wof:lastmodified":1695886505,
     "wof:name":"Qiqiha'er",
     "wof:parent_id":85669849,
     "wof:placetype":"county",

--- a/data/890/516/485/890516485.geojson
+++ b/data/890/516/485/890516485.geojson
@@ -182,8 +182,13 @@
     "wof:concordances":{
         "gp:id":26198177,
         "hasc:id":"CN.GX.BS",
+        "meso:local_id":"73843931",
         "qs_pg:id":212458
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055960,
     "wof:geom_alt":[
@@ -200,7 +205,7 @@
         }
     ],
     "wof:id":890516485,
-    "wof:lastmodified":1694493375,
+    "wof:lastmodified":1695886038,
     "wof:name":"Baise",
     "wof:parent_id":85669717,
     "wof:placetype":"county",

--- a/data/890/516/487/890516487.geojson
+++ b/data/890/516/487/890516487.geojson
@@ -212,8 +212,13 @@
     "wof:concordances":{
         "gp:id":26198179,
         "hasc:id":"CN.GX.BH",
+        "meso:local_id":"73843734",
         "qs_pg:id":212459
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055960,
     "wof:geom_alt":[
@@ -230,7 +235,7 @@
         }
     ],
     "wof:id":890516487,
-    "wof:lastmodified":1694493399,
+    "wof:lastmodified":1695886132,
     "wof:name":"Beihai",
     "wof:parent_id":85669717,
     "wof:placetype":"county",

--- a/data/890/516/525/890516525.geojson
+++ b/data/890/516/525/890516525.geojson
@@ -188,8 +188,13 @@
     "wof:concordances":{
         "gp:id":26198118,
         "hasc:id":"CN.SA.BJ",
+        "meso:local_id":"73843794",
         "qs_pg:id":216000
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055962,
     "wof:geom_alt":[
@@ -206,7 +211,7 @@
         }
     ],
     "wof:id":890516525,
-    "wof:lastmodified":1694493400,
+    "wof:lastmodified":1695886135,
     "wof:name":"Baoji",
     "wof:parent_id":85669769,
     "wof:placetype":"county",

--- a/data/890/516/537/890516537.geojson
+++ b/data/890/516/537/890516537.geojson
@@ -202,8 +202,13 @@
         "gn:id":1786769,
         "gp:id":26198377,
         "hasc:id":"CN.SC.YB",
+        "meso:local_id":"73843791",
         "qs_pg:id":218897
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055963,
     "wof:geom_alt":[
@@ -220,7 +225,7 @@
         }
     ],
     "wof:id":890516537,
-    "wof:lastmodified":1694493398,
+    "wof:lastmodified":1695886130,
     "wof:name":"Yibin",
     "wof:parent_id":85669787,
     "wof:placetype":"county",

--- a/data/890/516/549/890516549.geojson
+++ b/data/890/516/549/890516549.geojson
@@ -199,8 +199,13 @@
         "gn:id":1812954,
         "gp:id":26198088,
         "hasc:id":"CN.SD.DZ",
+        "meso:local_id":"73843822",
         "qs_pg:id":219133
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055963,
     "wof:geom_alt":[
@@ -217,7 +222,7 @@
         }
     ],
     "wof:id":890516549,
-    "wof:lastmodified":1694493399,
+    "wof:lastmodified":1695886134,
     "wof:name":"Dezhou",
     "wof:parent_id":85669813,
     "wof:placetype":"county",

--- a/data/890/516/551/890516551.geojson
+++ b/data/890/516/551/890516551.geojson
@@ -211,8 +211,13 @@
         "gn:id":1792891,
         "gp:id":26198126,
         "hasc:id":"CN.GS.TS",
+        "meso:local_id":"73843776",
         "qs_pg:id":219134
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055963,
     "wof:geom_alt":[
@@ -229,7 +234,7 @@
         }
     ],
     "wof:id":890516551,
-    "wof:lastmodified":1694493397,
+    "wof:lastmodified":1695886127,
     "wof:name":"Tianshui",
     "wof:parent_id":85669711,
     "wof:placetype":"county",

--- a/data/890/516/553/890516553.geojson
+++ b/data/890/516/553/890516553.geojson
@@ -256,8 +256,13 @@
         "gn:id":1799395,
         "gp:id":26198144,
         "hasc:id":"CN.ZJ.NB",
+        "meso:local_id":"73843784",
         "qs_pg:id":219963
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055963,
     "wof:geom_alt":[
@@ -274,7 +279,7 @@
         }
     ],
     "wof:id":890516553,
-    "wof:lastmodified":1694493377,
+    "wof:lastmodified":1695886043,
     "wof:name":"Ningbo",
     "wof:parent_id":85669835,
     "wof:placetype":"county",

--- a/data/890/516/555/890516555.geojson
+++ b/data/890/516/555/890516555.geojson
@@ -349,8 +349,13 @@
         "gn:id":1808925,
         "gp:id":26198147,
         "hasc:id":"CN.ZJ.HZ",
+        "meso:local_id":"73843858",
         "qs_pg:id":219964
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055963,
     "wof:geom_alt":[
@@ -367,7 +372,7 @@
         }
     ],
     "wof:id":890516555,
-    "wof:lastmodified":1694493377,
+    "wof:lastmodified":1695886043,
     "wof:name":"Hangzhou",
     "wof:parent_id":85669835,
     "wof:placetype":"county",

--- a/data/890/516/557/890516557.geojson
+++ b/data/890/516/557/890516557.geojson
@@ -451,8 +451,13 @@
         "gn:id":1791243,
         "gp:id":26198158,
         "hasc:id":"CN.HU.WH",
+        "meso:local_id":"73843871",
         "qs_pg:id":219965
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055963,
     "wof:geom_alt":[
@@ -469,7 +474,7 @@
         }
     ],
     "wof:id":890516557,
-    "wof:lastmodified":1694493375,
+    "wof:lastmodified":1695886037,
     "wof:name":"Wuhan",
     "wof:parent_id":85669777,
     "wof:placetype":"county",

--- a/data/890/516/559/890516559.geojson
+++ b/data/890/516/559/890516559.geojson
@@ -214,8 +214,13 @@
         "gn:id":1795873,
         "gp:id":26198168,
         "hasc:id":"CN.GD.SG",
+        "meso:local_id":"73844027",
         "qs_pg:id":219966
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055963,
     "wof:geom_alt":[
@@ -232,7 +237,7 @@
         }
     ],
     "wof:id":890516559,
-    "wof:lastmodified":1694493397,
+    "wof:lastmodified":1695886127,
     "wof:name":"Shaoguan",
     "wof:parent_id":85669743,
     "wof:placetype":"county",

--- a/data/890/516/561/890516561.geojson
+++ b/data/890/516/561/890516561.geojson
@@ -213,8 +213,13 @@
         "gn:id":1800794,
         "gp:id":26198169,
         "hasc:id":"CN.GD.MZ",
+        "meso:local_id":"73843866",
         "qs_pg:id":219967
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055963,
     "wof:geom_alt":[
@@ -231,7 +236,7 @@
         }
     ],
     "wof:id":890516561,
-    "wof:lastmodified":1694493397,
+    "wof:lastmodified":1695886128,
     "wof:name":"Meizhou",
     "wof:parent_id":85669743,
     "wof:placetype":"county",

--- a/data/890/516/563/890516563.geojson
+++ b/data/890/516/563/890516563.geojson
@@ -226,8 +226,13 @@
         "gn:id":1806783,
         "gp:id":26198174,
         "hasc:id":"CN.GD.HZ",
+        "meso:local_id":"73843828",
         "qs_pg:id":219968
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055964,
     "wof:geom_alt":[
@@ -244,7 +249,7 @@
         }
     ],
     "wof:id":890516563,
-    "wof:lastmodified":1694493398,
+    "wof:lastmodified":1695886131,
     "wof:name":"Huizhou",
     "wof:parent_id":85669743,
     "wof:placetype":"county",

--- a/data/890/516/567/890516567.geojson
+++ b/data/890/516/567/890516567.geojson
@@ -123,9 +123,14 @@
         "gn:id":1815285,
         "gp:id":26198200,
         "hasc:id":"CN.SC.CD",
+        "meso:local_id":"73843829",
         "qs_pg:id":219969,
         "wd:id":"Q13818660"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055964,
     "wof:geom_alt":[
@@ -142,7 +147,7 @@
         }
     ],
     "wof:id":890516567,
-    "wof:lastmodified":1694493388,
+    "wof:lastmodified":1695886493,
     "wof:name":"Chengdu",
     "wof:parent_id":85669787,
     "wof:placetype":"county",

--- a/data/890/516/569/890516569.geojson
+++ b/data/890/516/569/890516569.geojson
@@ -193,8 +193,13 @@
         "gn:id":2035516,
         "gp:id":26198229,
         "hasc:id":"CN.LN.PJ",
+        "meso:local_id":"73843934",
         "qs_pg:id":219970
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055964,
     "wof:geom_alt":[
@@ -211,7 +216,7 @@
         }
     ],
     "wof:id":890516569,
-    "wof:lastmodified":1694493374,
+    "wof:lastmodified":1695886036,
     "wof:name":"Panjin",
     "wof:parent_id":85669807,
     "wof:placetype":"county",

--- a/data/890/516/573/890516573.geojson
+++ b/data/890/516/573/890516573.geojson
@@ -205,8 +205,13 @@
         "gn:id":1796662,
         "gp:id":26198339,
         "hasc:id":"CN.FJ.SM",
+        "meso:local_id":"73843687",
         "qs_pg:id":219973
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055964,
     "wof:geom_alt":[
@@ -223,7 +228,7 @@
         }
     ],
     "wof:id":890516573,
-    "wof:lastmodified":1694493398,
+    "wof:lastmodified":1695886130,
     "wof:name":"Sanming",
     "wof:parent_id":85669735,
     "wof:placetype":"county",

--- a/data/890/516/575/890516575.geojson
+++ b/data/890/516/575/890516575.geojson
@@ -321,8 +321,13 @@
         "gn:id":1810815,
         "gp:id":26198341,
         "hasc:id":"CN.FJ.FZ",
+        "meso:local_id":"73843940",
         "qs_pg:id":219974
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055964,
     "wof:geom_alt":[
@@ -339,7 +344,7 @@
         }
     ],
     "wof:id":890516575,
-    "wof:lastmodified":1694493376,
+    "wof:lastmodified":1695886039,
     "wof:name":"Fuzhou",
     "wof:parent_id":85669735,
     "wof:placetype":"county",

--- a/data/890/516/577/890516577.geojson
+++ b/data/890/516/577/890516577.geojson
@@ -193,8 +193,13 @@
         "gn:id":1799392,
         "gp:id":26198343,
         "hasc:id":"CN.FJ.ND",
+        "meso:local_id":"73843783",
         "qs_pg:id":219975
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055964,
     "wof:geom_alt":[
@@ -211,7 +216,7 @@
         }
     ],
     "wof:id":890516577,
-    "wof:lastmodified":1694493378,
+    "wof:lastmodified":1695886045,
     "wof:name":"Ningde",
     "wof:parent_id":85669735,
     "wof:placetype":"county",

--- a/data/890/516/579/890516579.geojson
+++ b/data/890/516/579/890516579.geojson
@@ -205,8 +205,13 @@
         "gn:id":1817965,
         "gp:id":26198355,
         "hasc:id":"CN.GZ.AS",
+        "meso:local_id":"73843788",
         "qs_pg:id":219976
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055964,
     "wof:geom_alt":[
@@ -223,7 +228,7 @@
         }
     ],
     "wof:id":890516579,
-    "wof:lastmodified":1694493400,
+    "wof:lastmodified":1695886135,
     "wof:name":"Anshun",
     "wof:parent_id":85669721,
     "wof:placetype":"county",

--- a/data/890/516/581/890516581.geojson
+++ b/data/890/516/581/890516581.geojson
@@ -286,8 +286,13 @@
         "gn:id":1809458,
         "gp:id":26198356,
         "hasc:id":"CN.GZ.GY",
+        "meso:local_id":"73843971",
         "qs_pg:id":219977
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055964,
     "wof:geom_alt":[
@@ -304,7 +309,7 @@
         }
     ],
     "wof:id":890516581,
-    "wof:lastmodified":1694493376,
+    "wof:lastmodified":1695886040,
     "wof:name":"Guiyang",
     "wof:parent_id":85669721,
     "wof:placetype":"county",

--- a/data/890/516/585/890516585.geojson
+++ b/data/890/516/585/890516585.geojson
@@ -250,8 +250,13 @@
         "gn:id":1793343,
         "gp:id":26198366,
         "hasc:id":"CN.HB.TS",
+        "meso:local_id":"73843761",
         "qs_pg:id":219978
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055964,
     "wof:geom_alt":[
@@ -268,7 +273,7 @@
         }
     ],
     "wof:id":890516585,
-    "wof:lastmodified":1694493377,
+    "wof:lastmodified":1695886045,
     "wof:name":"Tangshan",
     "wof:parent_id":85669797,
     "wof:placetype":"county",

--- a/data/890/516/587/890516587.geojson
+++ b/data/890/516/587/890516587.geojson
@@ -179,8 +179,13 @@
     "wof:concordances":{
         "gp:id":26198122,
         "hasc:id":"CN.SA.YA",
+        "meso:local_id":"73843814",
         "qs_pg:id":220001
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055964,
     "wof:geom_alt":[
@@ -197,7 +202,7 @@
         }
     ],
     "wof:id":890516587,
-    "wof:lastmodified":1694493377,
+    "wof:lastmodified":1695886042,
     "wof:name":"Yan'an",
     "wof:parent_id":85669769,
     "wof:placetype":"county",

--- a/data/890/516/595/890516595.geojson
+++ b/data/890/516/595/890516595.geojson
@@ -196,8 +196,13 @@
         "gn:id":1808391,
         "gp:id":26198361,
         "hasc:id":"CN.HB.HS",
+        "meso:local_id":"73843962",
         "qs_pg:id":10342
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055965,
     "wof:geom_alt":[
@@ -214,7 +219,7 @@
         }
     ],
     "wof:id":890516595,
-    "wof:lastmodified":1694493397,
+    "wof:lastmodified":1695886127,
     "wof:name":"Hengshui",
     "wof:parent_id":85669797,
     "wof:placetype":"county",

--- a/data/890/516/617/890516617.geojson
+++ b/data/890/516/617/890516617.geojson
@@ -311,8 +311,13 @@
         "gn:id":1810818,
         "gp:id":26198154,
         "hasc:id":"CN.JX.FZ",
+        "meso:local_id":"73843832",
         "qs_pg:id":221224
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055965,
     "wof:geom_alt":[
@@ -329,7 +334,7 @@
         }
     ],
     "wof:id":890516617,
-    "wof:lastmodified":1694493375,
+    "wof:lastmodified":1695886038,
     "wof:name":"Fuzhou",
     "wof:parent_id":85669823,
     "wof:placetype":"county",

--- a/data/890/516/621/890516621.geojson
+++ b/data/890/516/621/890516621.geojson
@@ -116,9 +116,14 @@
         "gn:id":2036646,
         "gp:id":26198223,
         "hasc:id":"CN.JL.BS",
+        "meso:local_id":"73843928",
         "qs_pg:id":221225,
         "wk:page":"\u767d\u5c71"
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055965,
     "wof:geom_alt":[
@@ -135,7 +140,7 @@
         }
     ],
     "wof:id":890516621,
-    "wof:lastmodified":1694493397,
+    "wof:lastmodified":1695886128,
     "wof:name":"Baishan",
     "wof:parent_id":85669843,
     "wof:placetype":"county",

--- a/data/890/516/651/890516651.geojson
+++ b/data/890/516/651/890516651.geojson
@@ -211,8 +211,13 @@
         "gn:id":1799838,
         "gp:id":26198342,
         "hasc:id":"CN.FJ.NP",
+        "meso:local_id":"73843739",
         "qs_pg:id":25449
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055966,
     "wof:geom_alt":[
@@ -229,7 +234,7 @@
         }
     ],
     "wof:id":890516651,
-    "wof:lastmodified":1694493398,
+    "wof:lastmodified":1695886130,
     "wof:name":"Nanping",
     "wof:parent_id":85669735,
     "wof:placetype":"county",

--- a/data/890/516/675/890516675.geojson
+++ b/data/890/516/675/890516675.geojson
@@ -193,8 +193,13 @@
         "gn:id":1808197,
         "gp:id":26198219,
         "hasc:id":"CN.SD.HZ",
+        "meso:local_id":"73843957",
         "qs_pg:id":230098
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055968,
     "wof:geom_alt":[
@@ -211,7 +216,7 @@
         }
     ],
     "wof:id":890516675,
-    "wof:lastmodified":1694493397,
+    "wof:lastmodified":1695886128,
     "wof:name":"Heze",
     "wof:parent_id":85669813,
     "wof:placetype":"county",

--- a/data/890/516/677/890516677.geojson
+++ b/data/890/516/677/890516677.geojson
@@ -208,8 +208,13 @@
         "gn:id":1810843,
         "gp:id":26198237,
         "hasc:id":"CN.AH.FY",
+        "meso:local_id":"73844011",
         "qs_pg:id":230102
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055968,
     "wof:geom_alt":[
@@ -226,7 +231,7 @@
         }
     ],
     "wof:id":890516677,
-    "wof:lastmodified":1694493399,
+    "wof:lastmodified":1695886132,
     "wof:name":"Fuyang",
     "wof:parent_id":85669739,
     "wof:placetype":"county",

--- a/data/890/516/683/890516683.geojson
+++ b/data/890/516/683/890516683.geojson
@@ -208,8 +208,13 @@
         "gn:id":1807225,
         "gp:id":26198159,
         "hasc:id":"CN.HU.HS",
+        "meso:local_id":"73844037",
         "qs_pg:id":231610
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055968,
     "wof:geom_alt":[
@@ -226,7 +231,7 @@
         }
     ],
     "wof:id":890516683,
-    "wof:lastmodified":1694493399,
+    "wof:lastmodified":1695886133,
     "wof:name":"Huangshi",
     "wof:parent_id":85669777,
     "wof:placetype":"county",

--- a/data/890/516/735/890516735.geojson
+++ b/data/890/516/735/890516735.geojson
@@ -350,8 +350,13 @@
         "gn:id":2036499,
         "gp:id":26198064,
         "hasc:id":"CN.JL.JL",
+        "meso:local_id":"73843749",
         "qs_pg:id":238695
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055971,
     "wof:geom_alt":[
@@ -368,7 +373,7 @@
         }
     ],
     "wof:id":890516735,
-    "wof:lastmodified":1694493377,
+    "wof:lastmodified":1695886044,
     "wof:name":"Jilin",
     "wof:parent_id":85669843,
     "wof:placetype":"county",

--- a/data/890/516/865/890516865.geojson
+++ b/data/890/516/865/890516865.geojson
@@ -217,8 +217,13 @@
         "gn:id":1798445,
         "gp:id":26198340,
         "hasc:id":"CN.FJ.PT",
+        "meso:local_id":"73843955",
         "qs_pg:id":245362
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055980,
     "wof:geom_alt":[
@@ -235,7 +240,7 @@
         }
     ],
     "wof:id":890516865,
-    "wof:lastmodified":1694493399,
+    "wof:lastmodified":1695886134,
     "wof:name":"Putian",
     "wof:parent_id":85669735,
     "wof:placetype":"county",

--- a/data/890/516/905/890516905.geojson
+++ b/data/890/516/905/890516905.geojson
@@ -187,8 +187,13 @@
     "wof:concordances":{
         "gn:id":1815056,
         "hasc:id":"CN.HN.CZ",
+        "meso:local_id":"73843991",
         "qs_pg:id":1027710
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055983,
     "wof:geom_alt":[
@@ -205,7 +210,7 @@
         }
     ],
     "wof:id":890516905,
-    "wof:lastmodified":1694493398,
+    "wof:lastmodified":1695886131,
     "wof:name":"Chenzhou",
     "wof:parent_id":85669781,
     "wof:placetype":"county",

--- a/data/890/516/935/890516935.geojson
+++ b/data/890/516/935/890516935.geojson
@@ -205,8 +205,13 @@
     "wof:concordances":{
         "gn:id":1805178,
         "hasc:id":"CN.JX.JJ",
+        "meso:local_id":"73843709",
         "qs_pg:id":1027650
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055985,
     "wof:geom_alt":[
@@ -223,7 +228,7 @@
         }
     ],
     "wof:id":890516935,
-    "wof:lastmodified":1694493398,
+    "wof:lastmodified":1695886130,
     "wof:name":"Jiujiang",
     "wof:parent_id":85669823,
     "wof:placetype":"county",

--- a/data/890/516/975/890516975.geojson
+++ b/data/890/516/975/890516975.geojson
@@ -211,8 +211,13 @@
         "gn:id":1806534,
         "gp:id":26198141,
         "hasc:id":"CN.ZJ.HU",
+        "meso:local_id":"73843903",
         "qs_pg:id":1193693
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055989,
     "wof:geom_alt":[
@@ -229,7 +234,7 @@
         }
     ],
     "wof:id":890516975,
-    "wof:lastmodified":1694493400,
+    "wof:lastmodified":1695886135,
     "wof:name":"Huzhou",
     "wof:parent_id":85669835,
     "wof:placetype":"county",

--- a/data/890/516/977/890516977.geojson
+++ b/data/890/516/977/890516977.geojson
@@ -214,8 +214,13 @@
         "gn:id":1804539,
         "gp:id":26198363,
         "hasc:id":"CN.HB.LF",
+        "meso:local_id":"73843813",
         "qs_pg:id":1193881
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055989,
     "wof:geom_alt":[
@@ -232,7 +237,7 @@
         }
     ],
     "wof:id":890516977,
-    "wof:lastmodified":1694493398,
+    "wof:lastmodified":1695886130,
     "wof:name":"Langfang",
     "wof:parent_id":85669797,
     "wof:placetype":"county",

--- a/data/890/517/009/890517009.geojson
+++ b/data/890/517/009/890517009.geojson
@@ -178,8 +178,13 @@
     "wof:concordances":{
         "gn:id":1796667,
         "hasc:id":"CN.HE.SM",
+        "meso:local_id":"73843688",
         "qs_pg:id":903667
     },
+    "wof:concordances_official":"meso:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"CN",
     "wof:created":1469055990,
     "wof:geom_alt":[
@@ -196,7 +201,7 @@
         }
     ],
     "wof:id":890517009,
-    "wof:lastmodified":1694493374,
+    "wof:lastmodified":1695886036,
     "wof:name":"Sanmenxia",
     "wof:parent_id":85669801,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.