### PR TITLE
Update name postfixes

### DIFF
--- a/data/124/351/917/7/1243519177.geojson
+++ b/data/124/351/917/7/1243519177.geojson
@@ -30,17 +30,23 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Holoin"
+    ],
+    "name:eng_x_variant":[
+        "Holoin Gun"
+    ],
     "name:und_x_variant":[
         "Hao-lai-Kung",
         "Holoin Gun"
     ],
     "src:geom":"geonames",
     "wof:belongsto":[
-        85669847,
         102191569,
         85632695,
+        1108732533,
         136253041,
-        1108732533
+        85669847
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -59,8 +65,8 @@
         }
     ],
     "wof:id":1243519177,
-    "wof:lastmodified":1566696245,
-    "wof:name":"Holoin Gun",
+    "wof:lastmodified":1730271654,
+    "wof:name":"Holoin",
     "wof:parent_id":1108732533,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-cn",

--- a/data/125/936/704/5/1259367045.geojson
+++ b/data/125/936/704/5/1259367045.geojson
@@ -35,6 +35,12 @@
     "name:deu_x_preferred":[
         "Changyuan"
     ],
+    "name:eng_x_preferred":[
+        "Changyuan"
+    ],
+    "name:eng_x_variant":[
+        "Changyuan County"
+    ],
     "name:fas_x_preferred":[
         "\u0634\u0647\u0631\u0633\u062a\u0627\u0646 \u0686\u0627\u0646\u06af\u06cc\u0648\u0627\u0646"
     ],
@@ -61,11 +67,11 @@
     ],
     "src:geom":"geonames",
     "wof:belongsto":[
-        85669801,
         102191569,
         85632695,
+        890515625,
         136253041,
-        890515625
+        85669801
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -84,8 +90,8 @@
         }
     ],
     "wof:id":1259367045,
-    "wof:lastmodified":1566697916,
-    "wof:name":"Changyuan County",
+    "wof:lastmodified":1730095122,
+    "wof:name":"Changyuan",
     "wof:parent_id":890515625,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-cn",

--- a/data/125/945/317/1/1259453171.geojson
+++ b/data/125/945/317/1/1259453171.geojson
@@ -29,16 +29,22 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Qagan"
+    ],
+    "name:eng_x_variant":[
+        "Qagan Gu"
+    ],
     "name:mon_x_preferred":[
         "Qagan Gu"
     ],
     "src:geom":"geonames",
     "wof:belongsto":[
-        85669711,
         102191569,
         85632695,
+        890515159,
         136253041,
-        890515159
+        85669711
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":1259453171,
-    "wof:lastmodified":1566700376,
-    "wof:name":"Qagan Gu",
+    "wof:lastmodified":1730271666,
+    "wof:name":"Qagan",
     "wof:parent_id":890515159,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-cn",

--- a/data/129/344/042/9/1293440429.geojson
+++ b/data/129/344/042/9/1293440429.geojson
@@ -40,6 +40,9 @@
         "Wenshan"
     ],
     "name:eng_x_preferred":[
+        "Wenshan"
+    ],
+    "name:eng_x_variant":[
         "Wenshan City"
     ],
     "name:fin_x_preferred":[
@@ -79,11 +82,11 @@
     "src:geom":"geonames",
     "src:population":"geonames",
     "wof:belongsto":[
-        85669791,
         102191569,
         85632695,
+        1108732431,
         136253041,
-        1108732431
+        85669791
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -103,8 +106,8 @@
         }
     ],
     "wof:id":1293440429,
-    "wof:lastmodified":1566672076,
-    "wof:name":"Wenshan City",
+    "wof:lastmodified":1730095042,
+    "wof:name":"Wenshan",
     "wof:parent_id":1108732431,
     "wof:placetype":"locality",
     "wof:population":450000,

--- a/data/132/657/878/3/1326578783.geojson
+++ b/data/132/657/878/3/1326578783.geojson
@@ -29,13 +29,19 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Copu"
+    ],
+    "name:eng_x_variant":[
+        "Copu Si"
+    ],
     "src:geom":"geonames",
     "wof:belongsto":[
-        85669787,
         102191569,
         85632695,
+        890514703,
         136253041,
-        890514703
+        85669787
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":1326578783,
-    "wof:lastmodified":1566649777,
-    "wof:name":"Copu Si",
+    "wof:lastmodified":1730271566,
+    "wof:name":"Copu",
     "wof:parent_id":890514703,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-cn",

--- a/data/132/680/740/1/1326807401.geojson
+++ b/data/132/680/740/1/1326807401.geojson
@@ -29,16 +29,22 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Shifo"
+    ],
+    "name:eng_x_variant":[
+        "Shifo Si"
+    ],
     "name:zho_x_preferred":[
         "\u77f3\u4f5b\u5bfa"
     ],
     "src:geom":"geonames",
     "wof:belongsto":[
-        85669777,
         102191569,
         85632695,
+        890513331,
         136253041,
-        890513331
+        85669777
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":1326807401,
-    "wof:lastmodified":1566648170,
-    "wof:name":"Shifo Si",
+    "wof:lastmodified":1730271564,
+    "wof:name":"Shifo",
     "wof:parent_id":890513331,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-cn",

--- a/data/132/729/559/1/1327295591.geojson
+++ b/data/132/729/559/1/1327295591.geojson
@@ -29,13 +29,19 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Har"
+    ],
+    "name:eng_x_variant":[
+        "Har Gu"
+    ],
     "src:geom":"geonames",
     "wof:belongsto":[
-        85669847,
         102191569,
         85632695,
+        890514743,
         136253041,
-        890514743
+        85669847
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":1327295591,
-    "wof:lastmodified":1566655090,
-    "wof:name":"Har Gu",
+    "wof:lastmodified":1730271573,
+    "wof:name":"Har",
     "wof:parent_id":890514743,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-cn",

--- a/data/134/347/951/1/1343479511.geojson
+++ b/data/134/347/951/1/1343479511.geojson
@@ -35,6 +35,12 @@
     "name:deu_x_preferred":[
         "Zhongmu"
     ],
+    "name:eng_x_preferred":[
+        "Zhongmu"
+    ],
+    "name:eng_x_variant":[
+        "Zhongmu County"
+    ],
     "name:eus_x_preferred":[
         "Zhongmu konderria"
     ],
@@ -64,11 +70,11 @@
     ],
     "src:geom":"geonames",
     "wof:belongsto":[
-        85669801,
         102191569,
         85632695,
+        890515627,
         136253041,
-        890515627
+        85669801
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -88,8 +94,8 @@
         }
     ],
     "wof:id":1343479511,
-    "wof:lastmodified":1566660409,
-    "wof:name":"Zhongmu County",
+    "wof:lastmodified":1730095015,
+    "wof:name":"Zhongmu",
     "wof:parent_id":890515627,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-cn",

--- a/data/134/385/521/7/1343855217.geojson
+++ b/data/134/385/521/7/1343855217.geojson
@@ -29,6 +29,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Goinkongma"
+    ],
+    "name:eng_x_variant":[
+        "Goinkongma Si"
+    ],
     "name:und_x_variant":[
         "\u516c\u5171\u9a6c\u5bfa",
         "\u516c\u8d21\u9ebb",
@@ -36,11 +42,11 @@
     ],
     "src:geom":"geonames",
     "wof:belongsto":[
-        85669715,
         102191569,
         85632695,
+        890515873,
         136253041,
-        890515873
+        85669715
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -59,8 +65,8 @@
         }
     ],
     "wof:id":1343855217,
-    "wof:lastmodified":1566659884,
-    "wof:name":"Goinkongma Si",
+    "wof:lastmodified":1730271579,
+    "wof:name":"Goinkongma",
     "wof:parent_id":890515873,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-cn",

--- a/data/890/515/939/890515939.geojson
+++ b/data/890/515/939/890515939.geojson
@@ -43,6 +43,9 @@
     "name:eng_x_preferred":[
         "Changshu"
     ],
+    "name:eng_x_variant":[
+        "Changshu City"
+    ],
     "name:fas_x_preferred":[
         "\u0686\u0627\u0646\u06af\u0634\u0648"
     ],
@@ -210,8 +213,8 @@
         }
     ],
     "wof:id":890515939,
-    "wof:lastmodified":1587428662,
-    "wof:name":"Changshu City",
+    "wof:lastmodified":1730095104,
+    "wof:name":"Changshu",
     "wof:parent_id":890515879,
     "wof:placetype":"locality",
     "wof:population":1047700,

--- a/data/890/516/071/890516071.geojson
+++ b/data/890/516/071/890516071.geojson
@@ -19,17 +19,23 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":4.0,
+    "name:eng_x_preferred":[
+        "Zhu Cheng"
+    ],
+    "name:eng_x_variant":[
+        "Zhu Cheng City"
+    ],
     "qs:name":"Zhu Cheng City",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
     "qs:pop_sr":"11",
     "src:population":"geonames",
     "wof:belongsto":[
-        85669813,
         102191569,
         85632695,
+        890514755,
         136253041,
-        890514755
+        85669813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -51,8 +57,8 @@
         }
     ],
     "wof:id":890516071,
-    "wof:lastmodified":1566693607,
-    "wof:name":"Zhu Cheng City",
+    "wof:lastmodified":1730095103,
+    "wof:name":"Zhu Cheng",
     "wof:parent_id":890514755,
     "wof:placetype":"locality",
     "wof:population":1000000,


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2207.

This PR updates name properties for names with certain postfixes. The `wof:name` property and English preferred name values were updated to remove postfixes, and English variant names were adjusted/added to store the name with the postfix. Label properties were also updated, when present. No PIP work needed, property edits only.

Number of records updated: 11